### PR TITLE
Create CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,11 @@
+# Contributors
+
+This experiment is built by many contributors and volunteers. Thanks to all of them for their work!
+
+This list is manually curated to include valuable contributions by volunteers that do not include code, such as user testing, providing feedback, or mockups. Please edit this list to include new contributors as they come in. There is no particular order to this list. If you or someone else was omitted from this list, we assure you that was not intentional. 
+Please let us know and we'll add you. 
+
+| GitHub Username | WordPress.org Username|
+| --------------- | --------------------- |
+| @jffng | @jffng |
+| @kjellr | @kjellr |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@ This list is manually curated to include valuable contributions by volunteers th
 | @mtias | @mtias |
 | @jffng | @jffng |
 | @kjellr | @kjellr |
+| @bph | @bph |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,5 +7,6 @@ Please let us know and we'll add you.
 
 | GitHub Username | WordPress.org Username|
 | --------------- | --------------------- |
+| @mtias | @mtias |
 | @jffng | @jffng |
 | @kjellr | @kjellr |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,8 @@
 # Contributors
 
-This experiment is built by many contributors and volunteers. Thanks to all of them for their work!
+These experiments are built by many contributors and volunteers. Thanks to all of them for their work!
 
-This list is manually curated to include valuable contributions by volunteers that do not include code, such as user testing, providing feedback, or mockups. Please edit this list to include new contributors as they come in. There is no particular order to this list. If you or someone else was omitted from this list, we assure you that was not intentional. 
-Please let us know and we'll add you. 
+This list is manually curated to include valuable contributions by volunteers that do not include code, such as user testing, providing feedback, or mockups. Please edit this list to include new contributors as they come in. There is no particular order to this list. If you or someone else was omitted from this list, we assure you that was not intentional. Please let us know and we'll add you. 
 
 | GitHub Username | WordPress.org Username|
 | --------------- | --------------------- |


### PR DESCRIPTION
This PR adds a contributors page, in the vein of those in other WP.org repositories ([example](https://github.com/WordPress/design-experiments/blob/master/CONTRIBUTORS.md)).