### PR TITLE
Fix PHP syntax errors in #10

### DIFF
--- a/twentynineteen-blocks/functions.php
+++ b/twentynineteen-blocks/functions.php
@@ -101,7 +101,7 @@ if ( ! function_exists( 'twentynineteenblocks_theme_support' ) ) :
 						'',
 						array(
 							'<!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /-->',
-						),
+						)
 					),
 				),
 			]

--- a/twentytwenty-blocks/functions.php
+++ b/twentytwenty-blocks/functions.php
@@ -215,7 +215,7 @@ if ( ! function_exists( 'twentytwentyblocks_theme_support' ) ) :
 							'<!-- wp:gallery {"ids":[39,38],"align":"wide"} -->',
 							'<figure class="wp-block-gallery alignwide columns-2 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="' . get_theme_file_uri() . '/assets/images/2020-square-2.png" alt="" data-id="39" data-full-url="' . get_theme_file_uri() . '/assets/images/2020-square-2.png" data-link="assets/images/2020-square-2/" class="wp-image-39"/></figure></li><li class="blocks-gallery-item"><figure><img src="' . get_theme_file_uri() . '/assets/images/2020-square-1.png" alt="" data-id="38" data-full-url="' . get_theme_file_uri() . '/assets/images/2020-square-1.png" data-link="' . get_theme_file_uri() . '/assets/images/2020-square-1/" class="wp-image-38"/></figure></li></ul></figure>',
 							'<!-- /wp:gallery -->',
-						),
+						)
 					),
 				),
 				'about',
@@ -227,7 +227,7 @@ if ( ! function_exists( 'twentytwentyblocks_theme_support' ) ) :
 						'',
 						array(
 							'<!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /-->',
-						),
+						)
 					),
 				),
 			),


### PR DESCRIPTION
**Description**
Removes trailing commas in a `join` statement which throw syntax errors below php 7.3.

This PR addresses #10. 

**How to Test**
Run 'functions.php' through a php linter and ensure no errors are found