### PR TITLE
[Gutenberg Starter Theme] Remove non-gutenberg HTML in block template files

### DIFF
--- a/gutenberg-starter-theme-blocks/block-templates/index.html
+++ b/gutenberg-starter-theme-blocks/block-templates/index.html
@@ -1,12 +1,11 @@
-<header class="site-header">
-	<!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /-->
-</header>
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
+<!-- /wp:group -->
 
-<main class="site-content">
-	<!-- wp:post-title /-->
-	<!-- wp:post-content /-->
-</main>
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<!-- /wp:group -->
 
-<footer class="site-footer">
-	<!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /-->
-</footer>
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
+<!-- /wp:group -->

--- a/gutenberg-starter-theme-blocks/block-templates/index.html
+++ b/gutenberg-starter-theme-blocks/block-templates/index.html
@@ -2,9 +2,11 @@
 <div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","className":"site-content"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<!-- wp:group {"align":"full","className":"page-title"} -->
+<div class="wp-block-group alignfull page-title"><div class="wp-block-group__inner-container"><!-- wp:post-title /--></div></div>
 <!-- /wp:group -->
+
+<!-- wp:post-content /-->
 
 <!-- wp:group {"align":"full","className":"site-footer"} -->
 <div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /--></div></div>

--- a/gutenberg-starter-theme-blocks/block-templates/page-blog.html
+++ b/gutenberg-starter-theme-blocks/block-templates/page-blog.html
@@ -1,14 +1,11 @@
-<header class="site-header">
-	<!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /-->
-</header>
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
+<!-- /wp:group -->
 
-<main class="site-content">
-	<!-- wp:post-title /-->
-	<div class="entry-content">
-	<!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /-->
-	</div>
-</main>
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /--></div></div>
+<!-- /wp:group -->
 
-<footer class="site-footer">
-	<!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /-->
-</footer>
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
+<!-- /wp:group -->


### PR DESCRIPTION
The `<header>`, `<main>`, and `<footer>` elements inside of block-template files render as broken classic blocks in the experimental Site Editor. This PR changes those to use group blocks instead, which improves a user's ability to use that screen. This unfortunately loses those semantic tags, but it seems like the more appropriate thing to do until Gutenberg provides a way to create more semantic full-page markup natively. 

---

**Before**

![Screen Shot 2020-01-31 at 2 59 24 PM](https://user-images.githubusercontent.com/1202812/73570644-b6917780-443a-11ea-9ce5-1efb5100f022.png)

**After**

![Screen Shot 2020-01-31 at 2 58 58 PM](https://user-images.githubusercontent.com/1202812/73570655-babd9500-443a-11ea-9165-a663725ecddc.png)
