### PR TITLE
[Twenty Nineteen Blocks] Remove non-gutenberg HTML in block template files

### DIFF
--- a/twentynineteen-blocks/block-templates/index.html
+++ b/twentynineteen-blocks/block-templates/index.html
@@ -1,12 +1,11 @@
-<header class="site-header">
-	<!-- wp:template-part {"slug":"header","theme":"twentynineteen-blocks"} /-->
-</header>
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"twentynineteen-blocks"} /--></div></div>
+<!-- /wp:group -->
 
-<main class="site-content">
-	<!-- wp:post-title /-->
-	<!-- wp:post-content /-->
-</main>
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<!-- /wp:group -->
 
-<footer class="site-footer">
-	<!-- wp:template-part {"slug":"footer","theme":"twentynineteen-blocks"} /-->
-</footer>
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"twentynineteen-blocks"} /--></div></div>
+<!-- /wp:group -->

--- a/twentynineteen-blocks/style.css
+++ b/twentynineteen-blocks/style.css
@@ -99,13 +99,13 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 
 /* Post title positioning */
 
-.wp-site-blocks .site-content > h1:first-child {
+.wp-site-blocks .site-content > .wp-block-group__inner-container > h1:first-child {
   max-width: calc(100% - (2 * 1rem));
   margin: 0 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-  .wp-site-blocks .site-content > h1:first-child {
+  .wp-site-blocks .site-content > .wp-block-group__inner-container > h1:first-child {
     max-width: 80%;
     margin: 0 10%;
     padding: 0 60px;


### PR DESCRIPTION
(Same as #14, but for the Twenty Nineteen theme variant)

The `<header>`, `<main>`, and `<footer>` elements inside of block-template files render as broken classic blocks in the experimental Site Editor. This PR changes those to use group blocks instead, which improves a user's ability to use that screen. This unfortunately loses those semantic tags, but it seems like the more appropriate thing to do until Gutenberg provides a way to create more semantic full-page markup natively.

---

**Before**

![Screen Shot 2020-01-31 at 3 11 28 PM](https://user-images.githubusercontent.com/1202812/73571284-3b30c580-443c-11ea-845d-0bdc9e07944c.png)

**After**

![Screen Shot 2020-01-31 at 3 13 43 PM](https://user-images.githubusercontent.com/1202812/73571333-4f74c280-443c-11ea-8acf-c13b261aebb8.png)
