### PR TITLE
[Twenty Twenty Blocks] Remove non-gutenberg HTML in block template files

### DIFF
--- a/twentytwenty-blocks/block-templates/index.html
+++ b/twentytwenty-blocks/block-templates/index.html
@@ -1,12 +1,11 @@
-<header class="site-header">
-	<!-- wp:template-part {"slug":"header","theme":"twentytwenty-blocks"} /-->
-</header>
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"twentytwenty-blocks"} /--></div></div>
+<!-- /wp:group -->
 
-<main class="site-content">
-	<!-- wp:post-title /-->
-	<!-- wp:post-content /-->
-</main>
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<!-- /wp:group -->
 
-<footer id="site-footer" class="site-footer">
-	<!-- wp:template-part {"slug":"footer","theme":"twentytwenty-blocks"} /-->
-</footer>
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"twentytwenty-blocks"} /--></div></div>
+<!-- /wp:group -->

--- a/twentytwenty-blocks/style.css
+++ b/twentytwenty-blocks/style.css
@@ -22,6 +22,7 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 .site-header {
 	background-color: #fff;
 	padding: 3.4rem 1rem 0;
+	margin-top: 0;
 	width: 100%;
 	z-index: 2;
 }


### PR DESCRIPTION
Following the lead of #14 and #15. The `<header>`, `<main>`, and `<footer>` elements inside of block-template files render as broken classic blocks in the experimental Site Editor. This PR changes those to use group blocks instead, which improves a user's ability to use that screen.

---

Before:

<img width="1280" alt="Screen Shot 2020-02-12 at 2 25 45 PM" src="https://user-images.githubusercontent.com/1202812/74370453-2130a480-4da5-11ea-84c7-cdd0ee565055.png">

After:

<img width="1280" alt="Screen Shot 2020-02-12 at 2 19 52 PM" src="https://user-images.githubusercontent.com/1202812/74370468-24c42b80-4da5-11ea-8a66-51be919deffa.png">
