### PR TITLE
[Parisienne] Remove non-gutenberg HTML in block template files

### DIFF
--- a/parisienne/block-templates/index.html
+++ b/parisienne/block-templates/index.html
@@ -1,11 +1,11 @@
-<header class="site-header">
-	<!-- wp:template-part {"slug":"header","theme":"parisienne"} /-->
-</header>
+<!-- wp:group {"align":"full","className":"site-header"} -->
+<div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"parisienne"} /--></div></div>
+<!-- /wp:group -->
 
-<main class="site-content">
-	<!-- wp:post-content /-->
-</main>
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<!-- /wp:group -->
 
-<footer class="site-footer">
-	<!-- wp:template-part {"slug":"footer","theme":"parisienne"} /-->
-</footer>
+<!-- wp:group {"align":"full","className":"site-footer"} -->
+<div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"parisienne"} /--></div></div>
+<!-- /wp:group -->

--- a/parisienne/block-templates/index.html
+++ b/parisienne/block-templates/index.html
@@ -3,7 +3,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-content /--></div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer"} -->

--- a/parisienne/functions.php
+++ b/parisienne/functions.php
@@ -58,11 +58,8 @@ endif;
  * Register and Enqueue Styles.
  */
 function parisienne_register_styles() {
-
 	$theme_version = wp_get_theme()->get( 'Version' );
-
 	wp_enqueue_style( 'parisienne-style', get_stylesheet_uri(), array(), $theme_version );
-
 }
 
 add_action( 'wp_enqueue_scripts', 'parisienne_register_styles' );
@@ -100,6 +97,3 @@ function parisienne_block_editor_settings() {
 	) );
 }
 add_action( 'after_setup_theme', 'parisienne_block_editor_settings' );
-
-add_action('after_setup_theme', function () {
-});


### PR DESCRIPTION
Following the lead of #14 and #15 (and #16). The `<header>`, `<main>`, and `<footer>` elements inside of block-template files render as broken classic blocks in the experimental Site Editor. This PR changes those to use group blocks instead, which improves a user's ability to use that screen.

This PR also removes an unused function at the end of `functions.php`, and tidies up some spacing in there too. 