### PR TITLE
add the post comments block to 2019

### DIFF
--- a/twentynineteen-blocks/block-templates/singular.html
+++ b/twentynineteen-blocks/block-templates/singular.html
@@ -7,8 +7,14 @@
     <div class="wp-block-group__inner-container">
         <!-- wp:post-title /-->
         <!-- wp:post-content /-->
-        <!-- wp:post-comments-form /-->
-        <!-- wp:post-comments /-->
+        <!-- wp:group {"className":"comments-area"} -->
+		<div class="wp-block-group comments-area">
+			<div class="wp-block-group__inner-container">
+	        <!-- wp:post-comments-form /-->
+	        <!-- wp:post-comments /-->
+			</div>
+		</div>
+		<!-- /wp:group -->
     </div>
 </div>
 <!-- /wp:group -->

--- a/twentynineteen-blocks/block-templates/singular.html
+++ b/twentynineteen-blocks/block-templates/singular.html
@@ -3,7 +3,14 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:post-content /--></div></div>
+<div class="wp-block-group alignfull site-content">
+    <div class="wp-block-group__inner-container">
+        <!-- wp:post-title /-->
+        <!-- wp:post-content /-->
+        <!-- wp:post-comments-form /-->
+        <!-- wp:post-comments /-->
+    </div>
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer"} -->

--- a/twentynineteen-blocks/style.css
+++ b/twentynineteen-blocks/style.css
@@ -99,13 +99,13 @@ Tags: one-column, flexible-header, accessibility-ready, custom-colors, custom-me
 
 /* Site content positioning */
 
-.wp-site-blocks .site-content > .wp-block-group__inner-container > *:not(.align-full):not(.align-wide) {
+.wp-site-blocks .site-content > .wp-block-group__inner-container > *:not(.align-full):not(.align-wide):not(.comments-area) {
   max-width: calc(100% - (2 * 1rem));
   margin: 0 1rem;
 }
 
 @media only screen and (min-width: 768px) {
-	.wp-site-blocks .site-content > .wp-block-group__inner-container > *:not(.align-full):not(.align-wide) {
+	.wp-site-blocks .site-content > .wp-block-group__inner-container > *:not(.align-full):not(.align-wide):not(.comments-area) {
 		max-width: 80%;
 		margin: 0 10%;
 		padding: 0 60px;


### PR DESCRIPTION
This PR adds the recent core/post-comments block to the singular template of 2019-blocks.
The design is not exactly the same as 2019 because it uses the default comments template. 
Potentially, we could add a "comments.php" template to the theme and the block would pick it.