### PR TITLE
Use register_block_pattern() instead of deprecated register_pattern()

### DIFF
--- a/twentytwenty-blocks/functions.php
+++ b/twentytwenty-blocks/functions.php
@@ -313,8 +313,8 @@ add_action( 'wp_enqueue_scripts', 'twentytwentyblocks_register_styles' );
  * Register Block Patterns.
  */
 
-if ( function_exists( 'register_pattern' ) ) {
-	register_pattern (
+if ( function_exists( 'register_block_pattern' ) ) {
+	register_block_pattern (
 	    'twentytwenty-blocks/exhibitions-pattern',
 	    array (
 	        'title'   => __( 'Two columns of mixed content', 'twentytwenty' ),


### PR DESCRIPTION
This should fix deprecations notices like

```
Deprecated: register_pattern is deprecated since version Gutenberg 8.1.0! Use register_block_pattern() instead. in /var/www/html/wp-includes/functions.php on line 4726
```

that I'm currently getting in Site Editing when using an up-to-date Gutenberg git clone with this repo :slightly_smiling_face: 

Context for deprecation:

https://github.com/WordPress/gutenberg/issues/21655
https://github.com/WordPress/gutenberg/pull/21970
https://github.com/WordPress/gutenberg/pull/22177
https://github.com/WordPress/gutenberg/pull/22341

Pinging @melchoyce @kjellr @jffng @youknowriad for review :slightly_smiling_face: 