### PR TITLE
Gutenberg Starter Theme Blocks: Center align site title and menu

### DIFF
--- a/gutenberg-starter-theme-blocks/block-template-parts/header.html
+++ b/gutenberg-starter-theme-blocks/block-template-parts/header.html
@@ -1,6 +1,6 @@
-<!-- wp:site-title /-->
+<!-- wp:site-title {"align":"center"} /-->
 
-<!-- wp:navigation -->
+<!-- wp:navigation {"itemsJustification":"center"} -->
 <!-- wp:navigation-link {"label":"Home","title":"Home","type":"page","url":"/"} /-->
 
 <!-- wp:navigation-link {"label":"Blog","title":"Blog","url":"/blog"} /-->


### PR DESCRIPTION
The site title and navigation blocks now allow for center-alignment. This updates the header template part to reflect that. 

Before
![Screen Shot 2020-06-30 at 1 41 27 PM](https://user-images.githubusercontent.com/1202812/86159065-bc69b280-bad7-11ea-9079-abf1e3c354d9.png)

After
![Screen Shot 2020-06-30 at 1 41 50 PM](https://user-images.githubusercontent.com/1202812/86159066-bd024900-bad7-11ea-9e38-8825f801537d.png)
