### PR TITLE
Add line-height and link-color support for 2020/2019-blocks themes.

### DIFF
--- a/gutenberg-starter-theme-blocks/functions.php
+++ b/gutenberg-starter-theme-blocks/functions.php
@@ -18,6 +18,12 @@ if ( ! function_exists( 'gutenberg_starter_theme_blocks_support' ) ) :
 		// Adding support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 
+		// Add support for custom line height controls.
+		add_theme_support( 'custom-line-height' );
+
+		// Add support for experimental link color control.
+		add_theme_support( 'experimental-link-color' );
+
 		// Support a custom color palette.
 		add_theme_support( 'editor-color-palette', array(
 			array(

--- a/twentynineteen-blocks/functions.php
+++ b/twentynineteen-blocks/functions.php
@@ -1,9 +1,9 @@
 <?php
 
 if ( ! function_exists( 'twentynineteenblocks_theme_support' ) ) :
-    function twentynineteenblocks_theme_support()  {
+	function twentynineteenblocks_theme_support() {
 
-    	// Add default posts and comments RSS feed links to head.
+		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );
 
 		// Add support for Block Styles.
@@ -17,6 +17,12 @@ if ( ! function_exists( 'twentynineteenblocks_theme_support' ) ) :
 
 		// Enqueue editor styles.
 		add_editor_style( 'twentynineteen-styles/style-editor.css' );
+
+		// Add support for custom line height controls.
+		add_theme_support( 'custom-line-height' );
+
+		// Add support for experimental link color control.
+		add_theme_support( 'experimental-link-color' );
 
 		// Add custom editor font sizes.
 		add_theme_support(

--- a/twentytwenty-blocks/functions.php
+++ b/twentytwenty-blocks/functions.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! function_exists( 'twentytwentyblocks_theme_support' ) ) :
-    function twentytwentyblocks_theme_support()  {
+	function twentytwentyblocks_theme_support() {
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );
 
@@ -15,6 +15,12 @@ if ( ! function_exists( 'twentytwentyblocks_theme_support' ) ) :
 
 		// Enqueue editor styles.
 		add_editor_style( 'twentytwenty-styles/editor-style-block.css' );
+
+		// Add support for custom line height controls.
+		add_theme_support( 'custom-line-height' );
+
+		// Add support for experimental link color control.
+		add_theme_support( 'experimental-link-color' );
 
 		// Add custom editor font sizes.
 		add_theme_support(


### PR DESCRIPTION
Adds theme support for `custom-line-height` and `experimental-link-color` to twentynineteen-blocks and twentytwenty-blocks since these now require the theme to opt-in.  This will be helpful for development and testing purposes of the site editor, fse blocks, etc.  I assume we would want these added @youknowriad / @kjellr ?  However, I am unsure about the other themes in the repo so have only added them here for now.

