### PR TITLE
Update Gutenberg Starter Theme Blocks templates

### DIFF
--- a/gutenberg-starter-theme-blocks/block-template-parts/footer.html
+++ b/gutenberg-starter-theme-blocks/block-template-parts/footer.html
@@ -1,3 +1,3 @@
-<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
-<p class="has-text-align-center has-small-font-size">Proudly powered by <a href="https://wordpress.org">WordPress</a> | <a href="https://www.github.com/WordPress/gutenberg-starter-theme">The Gutenberg Starter Theme</a></p>
+<!-- wp:paragraph {"align":"center","fontSize":"small","style":{"color":{"text":"#6c7781"}}} -->
+<p class="has-text-align-center has-small-font-size" style="color:#6c7781">Proudly powered by <a href="https://wordpress.org">WordPress</a> | <a href="https://www.github.com/WordPress/gutenberg-starter-theme">The Gutenberg Starter Theme</a></p>
 <!-- /wp:paragraph -->

--- a/gutenberg-starter-theme-blocks/block-template-parts/header.html
+++ b/gutenberg-starter-theme-blocks/block-template-parts/header.html
@@ -1,7 +1,17 @@
-<!-- wp:site-title {"align":"center"} /-->
+<!-- wp:spacer {"height":34} -->
+<div style="height:34px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+<!-- wp:site-title {"textAlign":"center"} /-->
+<!-- wp:site-tagline {"textAlign":"center","style":{"color":{"text":"#6c7781"}}} /-->
+<!-- wp:spacer {"height":34} -->
+<div style="height:34px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:navigation {"itemsJustification":"center"} -->
 <!-- wp:navigation-link {"label":"Home","title":"Home","type":"page","url":"/"} /-->
 
 <!-- wp:navigation-link {"label":"Blog","title":"Blog","url":"/blog"} /-->
 <!-- /wp:navigation -->
+<!-- wp:spacer {"height":52} -->
+<div style="height:52px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/gutenberg-starter-theme-blocks/block-templates/index.html
+++ b/gutenberg-starter-theme-blocks/block-templates/index.html
@@ -2,11 +2,15 @@
 <div class="wp-block-group alignfull site-header"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"header","theme":"gutenberg-starter-theme-blocks"} /--></div></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","className":"page-title"} -->
-<div class="wp-block-group alignfull page-title"><div class="wp-block-group__inner-container"><!-- wp:post-title /--></div></div>
-<!-- /wp:group -->
+<!-- wp:group {"align":"full","className":"site-content"} -->
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
+<!-- wp:query-loop -->
+<!-- wp:post-title /-->
 
 <!-- wp:post-content /-->
+<!-- /wp:query-loop -->
+</div></div>
+<!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer"} -->
 <div class="wp-block-group alignfull site-footer"><div class="wp-block-group__inner-container"><!-- wp:template-part {"slug":"footer","theme":"gutenberg-starter-theme-blocks"} /--></div></div>

--- a/gutenberg-starter-theme-blocks/block-templates/single.html
+++ b/gutenberg-starter-theme-blocks/block-templates/single.html
@@ -3,7 +3,11 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-content"} -->
-<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container"><!-- wp:post-title /--><!-- wp:latest-posts {"postsToShow":100,"displayPostContent":true,"displayPostDate":true} /--></div></div>
+<div class="wp-block-group alignfull site-content"><div class="wp-block-group__inner-container">
+<!-- wp:post-title /-->
+<!-- wp:post-content /-->
+<!-- wp:post-comments /-->
+</div></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","className":"site-footer"} -->

--- a/gutenberg-starter-theme-blocks/css/blocks.css
+++ b/gutenberg-starter-theme-blocks/css/blocks.css
@@ -125,7 +125,7 @@
 ## Group
 --------------------------------------------------------------*/
 
-.wp-block-group > .wp-block-group__inner-container > * {
+.wp-block-group > .wp-block-group__inner-container > *:not(.entry-content) {
   max-width: 580px;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
While writing https://github.com/WordPress/gutenberg-starter-theme/pull/104, I noticed that some of the templates here in the Gutenberg Starter Theme Blocks could use some udpates. This PR includes a few changes: 

- It updates the tagline and footer text colors to match the usual theme colors (I wonder if this should map to what's in `experimental-theme.json` though. 🤔)
- It adjusts the spacing of the header to better match the usual layout. 
- It uses the query block rather than the latest posts block to show single posts. 
- It moves the single post view to a `single.html` template instead of the `index.html` template.
- It changes some CSS to allow for alignments to work as expected in the query block. 