### PR TITLE
Twenty Twenty-One Blocks: Minor cleanup

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -149,7 +149,6 @@ hr.is-style-twentytwentyone-separator-thick,
 --------------------------------------------------------------*/
 
 h1.wp-block-site-title {
-	font-size: calc(1px * var(--wp--preset--font-size--normal));
 	font-weight: var(--wp--custom--font-weight-normal);
 	text-transform: uppercase;
 }

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -198,5 +198,12 @@
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}
+	},
+	"core/site-title": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--normal)"
+			}
+		}
 	}
 }

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -47,7 +47,6 @@
 				]
 			},
 			"typography": {
-				"customFontSize": true,
 				"customLineHeight": true,
 				"fontSizes": [
 					{

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -121,18 +121,6 @@
 			}
 		}
 	},
-	"core/paragraph": {
-		"styles": {
-			"color": {
-				"text": "var(--wp--custom--color--primary)",
-				"link": "var(--wp--custom--color--primary)"
-			},
-			"typography": {
-				"fontSize": "var(--wp--preset--font-size--normal)",
-				"lineHeight": "var(--wp--custom--line-height--body)"
-			}
-		}
-	},
 	"core/heading/h1": {
 		"styles": {
 			"color": {

--- a/twentytwentyone-blocks/functions.php
+++ b/twentytwentyone-blocks/functions.php
@@ -25,13 +25,6 @@ if ( ! function_exists( 'twenty_twenty_one_blocks_setup' ) ) {
 		add_theme_support( 'automatic-feed-links' );
 
 		/*
-		 * Let WordPress manage the document title.
-		 * This theme does not use a hard-coded <title> tag in the document head,
-		 * WordPress will provide it for us.
-		 */
-		add_theme_support( 'title-tag' );
-
-		/*
 		 * Enable support for Post Thumbnails on posts and pages.
 		 *
 		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/


### PR DESCRIPTION
This PR takes care of a handful of minor notes from @jorgefilipecosta and @carolinan on the original PR: 

- Removes unnecessary title tag theme support. ([Reference](https://github.com/WordPress/theme-experiments/pull/57/files#r514006754))
- Removes the customFontSize opt-in from theme.json (since this is on by default). ([Reference](https://github.com/WordPress/theme-experiments/pull/57/files#r514260804))
- Moves the site title font size rule to theme.json. ([Reference](https://github.com/WordPress/theme-experiments/pull/57/files#r513731870))
- Removes an unnecessary set of theme.json rules for the paragraph block. These can just be inherited from the global rules. ([Reference](https://github.com/WordPress/theme-experiments/pull/57/files#r513741949))

None of these should have any visual or functional effect on the theme. 