### PR TITLE
Twenty Twenty-One Blocks: Update page header design

### DIFF
--- a/twentytwentyone-blocks/block-templates/page.html
+++ b/twentytwentyone-blocks/block-templates/page.html
@@ -1,6 +1,11 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full"} /-->
 
-<!-- wp:post-title /-->
+<!-- wp:post-title {"level":1,"align":"wide"} /-->
+
+<!-- wp:separator {"align":"wide","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
 <!-- wp:post-content /-->
 
 <!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full"} /-->

--- a/twentytwentyone-blocks/block-templates/page.html
+++ b/twentytwentyone-blocks/block-templates/page.html
@@ -6,6 +6,10 @@
 <hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
 <!-- /wp:separator -->
 
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:post-content /-->
 
 <!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full"} /-->

--- a/twentytwentyone-blocks/block-templates/single.html
+++ b/twentytwentyone-blocks/block-templates/single.html
@@ -6,6 +6,10 @@
 <hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
 <!-- /wp:separator -->
 
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:post-content /-->
 <!-- wp:post-comments /-->
 

--- a/twentytwentyone-blocks/block-templates/single.html
+++ b/twentytwentyone-blocks/block-templates/single.html
@@ -1,6 +1,11 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full"} /-->
 
-<!-- wp:post-title /-->
+<!-- wp:post-title {"level":1,"align":"wide"} /-->
+
+<!-- wp:separator {"align":"wide","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
 <!-- wp:post-content /-->
 <!-- wp:post-comments /-->
 


### PR DESCRIPTION
Fixes #60.

Note that this is dependent on https://github.com/WordPress/gutenberg/pull/26601: The post title block doesn't support wide alignment yet, but it should. 

To test, view a single post/page template in the site editor and on the front end. 

Before|After
---|---
![Screen Shot 2020-10-30 at 10 25 46 AM](https://user-images.githubusercontent.com/1202812/97716662-4895e180-1a9a-11eb-8d78-de680db126cd.png)|![Screen Shot 2020-10-30 at 10 20 52 AM](https://user-images.githubusercontent.com/1202812/97716668-4b90d200-1a9a-11eb-989a-81b65f2fc4c5.png)

