### PR TITLE
TT1: Update installation instructions to sync up with Gutenberg 9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is dedicated to exploring how WordPress themes can best leverage
 | [Gutenberg Starter Theme Blocks](https://github.com/WordPress/theme-experiments/tree/master/gutenberg-starter-theme-blocks) | Gutenberg 8.6 |
 | [Twenty Nineteen Blocks](https://github.com/WordPress/theme-experiments/tree/master/twentynineteen-blocks) | Gutenberg 8.6 |
 | [Twenty Twenty Blocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwenty-blocks) | Gutenberg 8.6 |
-| [Twenty Twenty-One Blocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwentyone-blocks) | Gutenberg 9.2.1 |
+| [Twenty Twenty-One Blocks](https://github.com/WordPress/theme-experiments/tree/master/twentytwentyone-blocks) | Gutenberg 9.3 |
 
 `require-gutenberg` _is a utility for themes to check whether the Gutenberg plugin is installed._
 

--- a/twentytwentyone-blocks/README.md
+++ b/twentytwentyone-blocks/README.md
@@ -2,7 +2,7 @@
 
 Ongoing development for the block-based version of Twenty Twenty-One, the default WordPress theme slated for 5.6. 
 
-This theme requires the Gutenberg Plugin to be installed, and the "Full Site Editing" experiment to be activated.
+This theme requires the Gutenberg Plugin to be installed (preferably version 9.3 or later).
 
 For the non-block-based version of this theme, please [visit the Twenty Twenty-One repository](https://github.com/WordPress/twentytwentyone). 
 

--- a/twentytwentyone-blocks/README.md
+++ b/twentytwentyone-blocks/README.md
@@ -10,14 +10,11 @@ To contribute to TT1 development, please read the [contributor's guide](/CONTRIB
 
 ## Installation
 
-1. In your admin panel, Install and Activate [the Gutenberg Plugin](https://wordpress.org/plugins/gutenberg/). 
-2. Visit the Gutenberg -> Experiments settings page and check the "Enable Full Site Editing" box. Save your changes. 
-3. Click the 'Code' button on [the main Theme Experiments Repository GitHub page](https://github.com/wordpress/theme-experiments).
-4. Unzip the resulting download. 
-4. Create a new zip file containing only the "twentytwentyone-blocks" folder. 
-4. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
-5. Click on 'Upload Theme', select the twentytwentyone-blocks zip file, and click on 'Install Now'.
-6. Click on the 'Activate' button to use your new theme.
+1. In your admin panel, install and activate [the Gutenberg Plugin](https://wordpress.org/plugins/gutenberg/). 
+2. Click the 'Code' button on [the main Theme Experiments Repository GitHub page](https://github.com/wordpress/theme-experiments).
+3. Unzip the resulting download. 
+4. Move or upload the "theme-experiments" folder into your site's `wp-content/themes` folder.
+6. Visit `Appearance > Themes` and activate the "Twenty Twenty-One Blocks" theme.
 
 ## Copyright
 


### PR DESCRIPTION
Updates the readme to remove the need for folks to check the "Full site editing" experiment, since this is [handled automatically](https://make.wordpress.org/core/2020/11/04/whats-new-in-gutenberg-4-november/) as of Gutenberg 9.3. 

Also removes the unzipping/re-zipping step, since https://github.com/WordPress/gutenberg/pull/26391 has been merged.