### PR TITLE
Add: Font family presets to 2021 blocks.

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -85,6 +85,29 @@
 						"name": "Gigantic"
 					}
 				],
+				"fontFamilies": [
+					{
+						"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+						"slug": "system-font",
+						"name": "System Font"
+					},
+					{
+						"fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+						"slug": "helvetica-arial"
+					},
+					{
+						"fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
+						"slug": "geneva-verdana"
+					},
+					{
+						"fontFamily": "Cambria, Georgia, serif",
+						"slug": "cambria-georgia"
+					},
+					{
+						"fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
+						"slug": "hoefler-times-new-roman"
+					}
+				],
 				"spacing": {
 					"customPadding": true,
 					"units": [ "px", "em", "rem", "vh", "vw" ]


### PR DESCRIPTION
This PR adds a set of font-family presets so we can take advantage and test the global styles font family picking mechanism.

For now, I'm adding just websafe fonts. I think it would be better If we add fonts that "look good" on this theme. cc: @kjellr, @jasmussen, @carolinan, @aristath  in case you have any font suggestions.