### PR TITLE
Twenty Twenty-One Blocks: Add post meta. 

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -186,7 +186,7 @@ hr[style*="text-align: right"],
 
 hr:not(.is-style-wide):not(.is-style-dots),
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
-	max-width: var(--responsive--aligndefault-width);
+	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 
 hr.alignwide:not(.is-style-wide):not(.is-style-dots),

--- a/twentytwentyone-blocks/block-templates/index.html
+++ b/twentytwentyone-blocks/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
 
-<!-- wp:query {"queryId":3,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <!-- wp:query-loop -->
 <!-- wp:post-title {"isLink":true} /-->
 

--- a/twentytwentyone-blocks/block-templates/index.html
+++ b/twentytwentyone-blocks/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <!-- wp:query-loop -->
 <!-- wp:post-title {"isLink":true} /-->
 

--- a/twentytwentyone-blocks/block-templates/index.html
+++ b/twentytwentyone-blocks/block-templates/index.html
@@ -1,8 +1,36 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
 
 <!-- wp:query-loop -->
-<!-- wp:post-title /-->
+<!-- wp:post-title {"isLink":true} /-->
+
 <!-- wp:post-content /-->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"align":"center","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator aligncenter is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-date /-->
+
+<!-- wp:post-author {"showAvatar":false} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-hierarchical-terms {"term":"category","textAlign":"right"} /-->
+
+<!-- wp:post-tags {"textAlign":"right"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- /wp:query-loop -->
 
 <!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->

--- a/twentytwentyone-blocks/block-templates/index.html
+++ b/twentytwentyone-blocks/block-templates/index.html
@@ -1,5 +1,6 @@
 <!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
 
+<!-- wp:query {"queryId":3,"query":{"perPage":10,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <!-- wp:query-loop -->
 <!-- wp:post-title {"isLink":true} /-->
 
@@ -32,5 +33,6 @@
 <!-- /wp:spacer -->
 
 <!-- /wp:query-loop -->
+<!-- /wp:query -->
 
 <!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->

--- a/twentytwentyone-blocks/block-templates/single.html
+++ b/twentytwentyone-blocks/block-templates/single.html
@@ -11,6 +11,32 @@
 <!-- /wp:spacer -->
 
 <!-- wp:post-content /-->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:separator {"align":"center","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator aligncenter is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-date /-->
+
+<!-- wp:post-author {"showAvatar":false,"byline":""} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:post-hierarchical-terms {"term":"category","textAlign":"right"} /-->
+
+<!-- wp:post-tags {"textAlign":"right"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 <!-- wp:post-comments /-->
 
 <!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -200,5 +200,37 @@
 				"fontSize": "var(--wp--preset--font-size--normal)"
 			}
 		}
+	},
+	"core/post-author": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"lineHeight": "var(--wp--custom--line-height--body)"
+			}
+		}
+	},
+	"core/post-date": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"lineHeight": "var(--wp--custom--line-height--body)"
+			}
+		}
+	},
+	"core/post-hierarchical-terms": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"lineHeight": "var(--wp--custom--line-height--body)"
+			}
+		}
+	},
+	"core/post-tags": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"lineHeight": "var(--wp--custom--line-height--body)"
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR adds post meta to the footer of posts. For reference, here are the original theme styles for these:

<img width="680" alt="Screen Shot 2020-11-04 at 2 12 54 PM" src="https://user-images.githubusercontent.com/1202812/98158631-36a4ac00-1ea9-11eb-8010-ca96a43db58e.png">

This PR gets somewhat close: 

<img width="731" alt="Screen Shot 2020-11-04 at 2 13 50 PM" src="https://user-images.githubusercontent.com/1202812/98158803-88e5cd00-1ea9-11eb-9098-7ef20f973260.png">

- It doesn't include any of the text before these, since the blocks don't support that yet. 
- It keeps the post author text in bold, since this is not yet changeable via Gutenberg or global styles. 

---

The PR adds this to the bottom of all single post pages, and also to each post in the main query loop. While I was in there, I made the post titles clickable, which makes this all work way better in general. 😄 

Example of a post in the main index feed: 

<img width="707" alt="Screen Shot 2020-11-04 at 2 40 43 PM" src="https://user-images.githubusercontent.com/1202812/98160202-d7946680-1eab-11eb-91f6-bc649a5ee206.png">
