### PR TITLE
Twenty Twenty-One Blocks: Add color name values to theme.json

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -6,43 +6,53 @@
 				"palette": [
 					{
 						"slug": "black",
-						"color": "#000000"
+						"color": "#000000",
+						"name": "Black"
 					},
 					{
 						"slug": "dark-gray",
-						"color": "#28303D"
+						"color": "#28303D",
+						"name": "Dark Gray"
 					},
 					{
 						"slug": "gray",
-						"color": "#39414D"
+						"color": "#39414D",
+						"name": "Gray"
 					},
 					{
 						"slug": "green",
-						"color": "#D1E4DD"
+						"color": "#D1E4DD",
+						"name": "Green"
 					},
 					{
 						"slug": "blue",
-						"color": "#D1DFE4"
+						"color": "#D1DFE4",
+						"name": "Blue"
 					},
 					{
 						"slug": "purple",
-						"color": "#D1D1E4"
+						"color": "#D1D1E4",
+						"name": "Purple"
 					},
 					{
 						"slug": "red",
-						"color": "#E4D1D1"
+						"color": "#E4D1D1",
+						"name": "Red"
 					},
 					{
 						"slug": "orange",
-						"color": "#E4DAD1"
+						"color": "#E4DAD1",
+						"name": "Orange"
 					},
 					{
 						"slug": "yellow",
-						"color": "#EEEADD"
+						"color": "#EEEADD",
+						"name": "Yellow"
 					},
 					{
 						"slug": "white",
-						"color": "#FFFFFF"
+						"color": "#FFFFFF",
+						"name": "White"
 					}
 				]
 			},


### PR DESCRIPTION
Enables these to show up as labels. 

Before|After
---|---
<img width="278" alt="Screen Shot 2020-11-04 at 3 20 12 PM" src="https://user-images.githubusercontent.com/1202812/98163752-3d372180-1eb1-11eb-9bd5-6db83b29616e.png">|<img width="278" alt="Screen Shot 2020-11-04 at 3 18 48 PM" src="https://user-images.githubusercontent.com/1202812/98163824-54760f00-1eb1-11eb-86ef-158a921a64b4.png">
