### PR TITLE
Twenty Twenty-One Blocks: Add gradient presets

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -2,7 +2,6 @@
 	"global": {
 		"settings": {
 			"color": {
-				"gradients": [ ],
 				"palette": [
 					{
 						"slug": "black",
@@ -43,6 +42,48 @@
 					{
 						"slug": "white",
 						"color": "#FFFFFF"
+					}
+				],
+				"gradients": [
+					{
+						"slug": "purple-to-yellow",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+						"name": "Purple to Yellow"
+					},
+					{
+						"slug": "yellow-to-purple",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+						"name": "Yellow to Purple"
+					},
+					{
+						"slug": "green-to-yellow",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+						"name": "Green to Yellow"
+					},
+					{
+						"slug": "yellow-to-green",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+						"name": "Yellow to Green"
+					},
+					{
+						"slug": "red-to-yellow",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+						"name": "Red to Yellow"
+					},
+					{
+						"slug": "yellow-to-red",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+						"name": "Yellow to Red"
+					},
+					{
+						"slug": "purple-to-red",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+						"name": "Purple to Red"
+					},
+					{
+						"slug": "red-to-purple",
+						"gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+						"name": "Red to Purple"
 					}
 				]
 			},


### PR DESCRIPTION
This PR adds Twenty Twenty-One's gradient presets to `theme.json`. It works just fine except that the gradients themselves aren't showing up in the swatches: 

<img width="270" alt="Screen Shot 2020-11-04 at 3 32 55 PM" src="https://user-images.githubusercontent.com/1202812/98165357-c2bbd100-1eb3-11eb-9386-c59cdd812a23.png">

This is a known Gutenberg problem and is tracked in https://github.com/WordPress/gutenberg/issues/26511. So I don't believe that should hold us back from merging this for now. 