### PR TITLE
Twenty Twenty-One Blocks: Use the correct font size + text decoration for the site title and description

### DIFF
--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -33,3 +33,10 @@ a:hover {
 	text-decoration-style: dotted;
 	text-decoration-skip-ink: none;
 }
+
+/*
+ * Gutenberg remotes this underline, but Twenty Twenty-One uses it. 
+ */
+.site-header h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
+	text-decoration: underline;
+}

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -268,10 +268,18 @@
 			}
 		}
 	},
+	"core/site-tagline": {
+		"styles": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--small)",
+				"lineHeight": 1.4
+			}
+		}
+	},
 	"core/site-title": {
 		"styles": {
 			"typography": {
-				"fontSize": "var(--wp--preset--font-size--normal)"
+				"fontSize": "var(--wp--preset--font-size--large)"
 			}
 		}
 	}


### PR DESCRIPTION
This PR: 

- Uses the correct font sizes for the site title and description.
- Brings back the underline for the site title. 

Original Theme|Before|After
---|---|---
![Screen Shot 2020-11-06 at 8 49 55 AM](https://user-images.githubusercontent.com/1202812/98373574-6f5d9600-200d-11eb-829f-53ce1582be46.png)|![Screen Shot 2020-11-06 at 8 50 53 AM](https://user-images.githubusercontent.com/1202812/98373577-708ec300-200d-11eb-9348-992a67f45082.png)|![Screen Shot 2020-11-06 at 8 49 48 AM](https://user-images.githubusercontent.com/1202812/98373578-71bff000-200d-11eb-8c79-59b87f22da5b.png)

(The main remaining difference here is the margin, but I'm not sure how to handle that yet — ideally that would be a Gutenberg setting. That shouldn't block these improvements though.)