### PR TITLE
Twenty Twenty-One Blocks: Add max-widths for alignments in the Site Editor

### DIFF
--- a/twentytwentyone-blocks/assets/css/style-editor.css
+++ b/twentytwentyone-blocks/assets/css/style-editor.css
@@ -1,0 +1,15 @@
+/*--------------------------------------------------------------
+# Editor Alignment Widths
+--------------------------------------------------------------*/
+
+.wp-block {
+	max-width: var(--wp--custom--responsive--aligndefault-width);
+}
+
+.wp-block[data-align="wide"] {
+	max-width: var(--wp--custom--responsive--alignwide-width);
+}
+
+.wp-block[data-align="full"] {
+	max-width: inherit;
+}


### PR DESCRIPTION
This solves (for now) this issue that I filed over here in the Gutenberg repo: https://github.com/WordPress/gutenberg/issues/26630

Basically, the Site Editor does not provide any max-widths out of the box for default and wide blocks. This PR adds them. We'll need this even when a solution for the upstream issue is in place, since we want to define our own widths here. 

Before|After
---|---
![Screen Shot 2020-11-09 at 4 04 38 PM](https://user-images.githubusercontent.com/1202812/98596541-9209dc00-22a5-11eb-9bd4-2bc62d54806e.png)|![Screen Shot 2020-11-09 at 4 03 07 PM](https://user-images.githubusercontent.com/1202812/98596553-93d39f80-22a5-11eb-8f07-20e11ff4e94c.png)
