### PR TITLE
Twenty Twenty-One Blocks: Add 404 Template

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -189,6 +189,8 @@ hr:not(.is-style-wide):not(.is-style-dots),
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 
+.wp-block[data-align="wide"] .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
+.wp-block[data-align="full"] .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
 hr.alignwide:not(.is-style-wide):not(.is-style-dots),
 .wp-block-separator.alignwide:not(.is-style-wide):not(.is-style-dots),
 hr.alignfull:not(.is-style-wide):not(.is-style-dots),

--- a/twentytwentyone-blocks/block-templates/404.html
+++ b/twentytwentyone-blocks/block-templates/404.html
@@ -1,0 +1,25 @@
+<!-- wp:template-part {"slug":"header","theme":"twentytwentyone-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
+
+<!-- wp:heading {"level":1,"align":"wide"} -->
+<h1 class="alignwide">Nothing Here</h1>
+<!-- /wp:heading -->
+
+<!-- wp:separator {"align":"wide","className":"is-style-twentytwentyone-separator-thick"} -->
+<hr class="wp-block-separator alignwide is-style-twentytwentyone-separator-thick"/>
+<!-- /wp:separator -->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph -->
+<p>It looks like nothing was found at this location. Maybe try a search?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:search {"label":"Search...","buttonText":"Search","buttonUseIcon":true} /-->
+
+<!-- wp:spacer {"height":70} -->
+<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:template-part {"slug":"footer","theme":"twentytwentyone-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
Closes #84.

Adds a basic 404 template, as per the designs. Does not style the search block, pending #82. 

The PR also fixes the display of wide/full separator blocks in the editor.

I can't get this working in the front end (is that a Gutenberg bug?), but I'm seeing it in the site editor: 

![Screen Shot 2020-11-17 at 1 50 23 PM](https://user-images.githubusercontent.com/1202812/99434575-f4ce2980-28dc-11eb-9003-82590b248313.png)
