### PR TITLE
Replace custom color variables with preset variables instead

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -3,7 +3,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-cover.is-style-twentytwentyone-border {
-	border: 3px solid var(--wp--custom--color--border);
+	border: 3px solid var(--wp--preset--color--dark-gray);
 }
 
 /*--------------------------------------------------------------
@@ -51,7 +51,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-group.is-style-twentytwentyone-border {
-	border: 3px solid var(--wp--custom--color--border);
+	border: 3px solid var(--wp--preset--color--dark-gray);
 	padding: var(--wp--custom--spacing--vertical) var(--wp--custom--spacing--horizontal);
 }
 
@@ -66,7 +66,7 @@
 
 .wp-block-image.is-style-twentytwentyone-border img,
 .wp-block-image.is-style-twentytwentyone-image-frame img {
-	border: 3px solid var(--wp--custom--color--border);
+	border: 3px solid var(--wp--preset--color--dark-gray);
 }
 
 .wp-block-image.is-style-twentytwentyone-image-frame img {
@@ -82,14 +82,14 @@
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers {
-	border-top: 3px solid var(--wp--custom--color--border);
-	border-bottom: 3px solid var(--wp--custom--color--border);
+	border-top: 3px solid var(--wp--preset--color--dark-gray);
+	border-bottom: 3px solid var(--wp--preset--color--dark-gray);
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers:not(.is-grid) > li,
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers > li {
 	padding-bottom: var(--wp--custom--spacing--vertical);
-	border-bottom: 1px solid var(--wp--custom--color--border);
+	border-bottom: 1px solid var(--wp--preset--color--dark-gray);
 	margin-top: var(--wp--custom--spacing--vertical);
 	margin-bottom: var(--wp--custom--spacing--vertical);
 }
@@ -101,8 +101,8 @@
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid {
-	box-shadow: inset 0 -1px 0 0 var(--wp--custom--color--border);
-	border-bottom: 2px solid var(--wp--custom--color--border);
+	box-shadow: inset 0 -1px 0 0 var(--wp--preset--color--dark-gray);
+	border-bottom: 2px solid var(--wp--preset--color--dark-gray);
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-dividers.is-grid li {
@@ -134,7 +134,7 @@
 }
 
 .wp-block-latest-posts.is-style-twentytwentyone-latest-posts-borders li {
-	border: 3px solid var(--wp--custom--color--border);
+	border: 3px solid var(--wp--preset--color--dark-gray);
 	padding: var(--wp--custom--spacing--vertical) var(--wp--custom--spacing--horizontal);
 }
 
@@ -152,7 +152,7 @@
 --------------------------------------------------------------*/
 
 .wp-block-media-text.is-style-twentytwentyone-border {
-	border: 3px solid var(--wp--custom--color--border);
+	border: 3px solid var(--wp--preset--color--dark-gray);
 }
 
 /*--------------------------------------------------------------
@@ -172,7 +172,7 @@
 
 hr,
 .wp-block-separator {
-	border-bottom: 1px solid var(--wp--custom--color--border);
+	border-bottom: 1px solid var(--wp--preset--color--dark-gray);
 	clear: both;
 	opacity: 1;
 }
@@ -181,7 +181,7 @@ hr[style*="text-align:right"],
 hr[style*="text-align: right"],
 .wp-block-separator[style*="text-align:right"],
 .wp-block-separator[style*="text-align: right"] {
-	border-right-color: var(--wp--custom--color--border);
+	border-right-color: var(--wp--preset--color--dark-gray);
 }
 
 hr:not(.is-style-wide):not(.is-style-dots),
@@ -236,7 +236,7 @@ h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 --------------------------------------------------------------*/
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
-	color: var(--wp--custom--color--primary);
+	color: var(--wp--preset--color--dark-gray);
 }
 
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -167,13 +167,6 @@
 			"custom": {
 				"font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
 				"font-weight-light": 300,
-				"color": {
-					"primary": "var(--wp--preset--color--dark-gray)",
-					"secondary": "var(--wp--preset--color--gray)",
-					"primary-hover": "var(--wp--custom--color-primary)",
-					"background": "var(--wp--preset--color--green)",
-					"border": "var(--wp--custom--color--primary)"
-				},
 				"line-height": {
 					"body": 1.7,
 					"heading": 1.3,
@@ -192,9 +185,9 @@
 		},
 		"styles": {
 	    	"color": {
-				"background": "var(--wp--custom--color--background)",
-				"text": "var(--wp--custom--color--primary)",
-				"link": "var(--wp--custom--color--primary)"
+				"background": "var(--wp--preset--color--green)",
+				"text": "var(--wp--preset--color--dark-gray)",
+				"link": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--normal)",
@@ -205,7 +198,7 @@
 	"core/heading/h1": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
@@ -216,7 +209,7 @@
 	"core/heading/h2": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
@@ -227,7 +220,7 @@
 	"core/heading/h3": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
@@ -238,7 +231,7 @@
 	"core/heading/h4": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
@@ -249,7 +242,7 @@
 	"core/heading/h5": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
@@ -260,7 +253,7 @@
 	"core/heading/h6": {
 		"styles": {
 			"color": {
-				"text": "var(--wp--custom--color--primary)"
+				"text": "var(--wp--preset--color--dark-gray)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",


### PR DESCRIPTION
This PR should have no effect on the visual appearance. 

When I originally ported over the colors from Twenty Twenty-One, I used some custom color variables in order to keep things straight. I forgot to take those out and use the original preset values instead, but forgot about it until now. 😄