### PR TITLE
Twenty Twenty One Blocks: Migrate Paragraph Block styles

### DIFF
--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -8,16 +8,6 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
-h1,
-.has-huge-font-size,
-.has-gigantic-font-size {
-	font-weight: var(--wp--preset--font-weight-light);
-}
-
-h2, h3, h4, h5, h6 {
-	font-weight: normal;
-}
-
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and

--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -11,7 +11,7 @@ body {
 h1,
 .has-huge-font-size,
 .has-gigantic-font-size {
-	font-weight: var(--wp--custom--font-weight-light);
+	font-weight: var(--wp--preset--font-weight-light);
 }
 
 h2, h3, h4, h5, h6 {
@@ -20,7 +20,7 @@ h2, h3, h4, h5, h6 {
 
 b,
 strong {
-	font-weight: 700;
+	font-weight: var(--wp--preset--font-weight--bold);
 }
 
 dfn,

--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -27,7 +27,7 @@ dfn,
 cite,
 em,
 i {
-	font-style: italic;
+	font-style: var(--wp--preset--font-style--italic);
 }
 
 pre {

--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -18,6 +18,24 @@ h2, h3, h4, h5, h6 {
 	font-weight: normal;
 }
 
+b,
+strong {
+	font-weight: 700;
+}
+
+dfn,
+cite,
+em,
+i {
+	font-style: italic;
+}
+
+pre {
+	white-space: pre;
+	overflow-x: auto;
+}
+
+
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and

--- a/twentytwentyone-blocks/assets/css/style-shared.css
+++ b/twentytwentyone-blocks/assets/css/style-shared.css
@@ -18,24 +18,6 @@ h2, h3, h4, h5, h6 {
 	font-weight: normal;
 }
 
-b,
-strong {
-	font-weight: var(--wp--preset--font-weight--bold);
-}
-
-dfn,
-cite,
-em,
-i {
-	font-style: var(--wp--preset--font-style--italic);
-}
-
-pre {
-	white-space: pre;
-	overflow-x: auto;
-}
-
-
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -143,6 +143,11 @@
 						"name": "Light"
 					},
 					{
+						"slug": "normal",
+						"value": "normal",
+						"name": "Normal"
+					},
+					{
 						"slug": "bold",
 						"value": 700,
 						"name": "Bold"

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -148,6 +148,11 @@
 						"name": "Normal"
 					},
 					{
+ 						"slug": "medium",
+ 						"value": "500",
+ 						"name": "Medium"
+ 					},
+ 					{
 						"slug": "semibold",
 						"value": 600,
 						"name": "Semibold"

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -148,6 +148,11 @@
 						"name": "Normal"
 					},
 					{
+						"slug": "semibold",
+						"value": 600,
+						"name": "Semibold"
+					},
+					{
 						"slug": "bold",
 						"value": 700,
 						"name": "Bold"

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -148,6 +148,18 @@
 						"name": "Bold"
 					}
 				],
+				"fontStyles": [
+					{
+						"slug": "normal",
+						"value": "normal",
+						"name": "Normal"
+					},
+					{
+						"slug": "italic",
+						"value": "italic",
+						"name": "Italic"
+					}
+				],
 				"fontFamilies": [
 					{
 						"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",

--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -136,6 +136,18 @@
 						"name": "Gigantic"
 					}
 				],
+				"fontWeights": [
+					{
+						"slug": "light",
+						"value": 300,
+						"name": "Light"
+					},
+					{
+						"slug": "bold",
+						"value": 700,
+						"name": "Bold"
+					}
+				],
 				"fontFamilies": [
 					{
 						"fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
@@ -166,7 +178,6 @@
 			},
 			"custom": {
 				"font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-				"font-weight-light": 300,
 				"line-height": {
 					"body": 1.7,
 					"heading": 1.3,


### PR DESCRIPTION
Added styles for `strong`, `b`, and other tags that affect the paragraph block (and others, of course):

https://github.com/WordPress/twentytwentyone/blob/trunk/assets/sass/04-elements/misc.scss

Related https://github.com/WordPress/theme-experiments/issues/91