### PR TITLE
Twenty Twenty-One Blocks: Migrate Image Block styles

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -59,9 +59,21 @@
 # Image
 --------------------------------------------------------------*/
 
-.wp-block-image img,
 .wp-block-image img {
 	height: auto;
+}
+
+.wp-block-image figcaption{
+	text-align: center;
+	color: var(--wp--preset--color--dark-gray);
+	font-size: var(--wp--preset--font-size--extra-small);
+	line-height: var(--wp--custom--line-height--body);
+	margin-top: calc(0.5 * var(--wp--custom--spacing--unit));
+	margin-bottom: var(--wp--custom--spacing--unit);
+}
+
+.wp-block-image a:focus img {
+	outline-offset: 2px;
 }
 
 .wp-block-image.is-style-twentytwentyone-border img,

--- a/twentytwentyone-blocks/style.css
+++ b/twentytwentyone-blocks/style.css
@@ -103,7 +103,7 @@ body {
 
 	.wp-site-blocks .alignfull {
 		transform: translateX(0px);
-		width: 100% + var(--wp--custom--spacing--horizontal));
+		width: 100% + var(--wp--custom--spacing--horizontal);
 		max-width: calc(100% + var(--wp--custom--spacing--horizontal));
 	}
 }


### PR DESCRIPTION
Migrated styles for Image Block.

There are issues that affect this block that would be solved by https://github.com/WordPress/gutenberg/issues/26633 and https://github.com/WordPress/gutenberg/issues/27116

Broken out of #82

Closes #92