### PR TITLE
Deploy TT1-blocks to a staging server when code is merged to master

### DIFF
--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         local-dir: twentytwentyone-blocks/
         # Deployment destination server & path. Formatted as protocol://domain.com:port/full/destination/path/
-        ftp-server: sftp://2021blocks.wordpress.net:22/home/blockswordpress/public_html/wp-content/themes
+        ftp-server: sftp://2021blocks.wordpress.net:22/home/blockswordpress/public_html/wp-content/themes/twentytwentyone-blocks
         # FTP account username
         ftp-username: ${{ secrets.TT1BLOCKS_STAGING_SFTP_USERNAME }}
         # FTP account password

--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -1,0 +1,25 @@
+
+name: Deploy to staging
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: FTP Deploy
+      uses: SamKirkland/FTP-Deploy-Action@3.0.0
+      with:
+        local-dir: twentytwentyone-blocks/
+        # Deployment destination server & path. Formatted as protocol://domain.com:port/full/destination/path/
+        ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/twentytwentyone-blocks/
+        # FTP account username
+        ftp-username: ${{ secrets.SFTP_USERNAME }}
+        # FTP account password
+        ftp-password: ${{ secrets.SFTP_PASSWORD }}
+        git-ftp-args: --insecure

--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         # Deployment destination server & path. Formatted as protocol://domain.com:port/full/destination/path/
         ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/twentytwentyone-blocks/
         # FTP account username
-        ftp-username: ${{ secrets.SFTP_USERNAME }}
+        ftp-username: ${{ secrets.TT1BLOCKS_STAGING_SFTP_USERNAME }}
         # FTP account password
-        ftp-password: ${{ secrets.SFTP_PASSWORD }}
+        ftp-password: ${{ secrets.TT1BLOCKS_STAGING_SFTP_PASSWORD }}
         git-ftp-args: --insecure

--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         local-dir: twentytwentyone-blocks/
         # Deployment destination server & path. Formatted as protocol://domain.com:port/full/destination/path/
-        ftp-server: sftp://sftp.pressable.com:22/htdocs/wp-content/themes/twentytwentyone-blocks/
+        ftp-server: sftp://2021blocks.wordpress.net:22/public-html/wp-content/themes/twentytwentyone-blocks/
         # FTP account username
         ftp-username: ${{ secrets.TT1BLOCKS_STAGING_SFTP_USERNAME }}
         # FTP account password

--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         local-dir: twentytwentyone-blocks/
         # Deployment destination server & path. Formatted as protocol://domain.com:port/full/destination/path/
-        ftp-server: sftp://2021blocks.wordpress.net:22/public-html/wp-content/themes/twentytwentyone-blocks/
+        ftp-server: sftp://2021blocks.wordpress.net:22/home/blockswordpress/public_html/wp-content/themes
         # FTP account username
         ftp-username: ${{ secrets.TT1BLOCKS_STAGING_SFTP_USERNAME }}
         # FTP account password

--- a/.github/workflows/tt1-blocks-staging-deploy.yml
+++ b/.github/workflows/tt1-blocks-staging-deploy.yml
@@ -23,3 +23,5 @@ jobs:
         # FTP account password
         ftp-password: ${{ secrets.TT1BLOCKS_STAGING_SFTP_PASSWORD }}
         git-ftp-args: --insecure
+    
+    


### PR DESCRIPTION
This change adds a GitHub action to deploy the TwentyTwentyOne-Blocks theme to the staging site: https://2021blocks.wordpress.net/ any time code is merged to /master

This gives an up-to-date snapshot of the currently accepted state of the theme.

Prior to bringing this change in the repository should be setup to provide TT1BLOCKS_STAGING_SFTP_USERNAME and TT1BLOCKS_STAGING_SFTP_PASSWORD as GitHub Secrets.

This change should be squash-merged as there is a fair bit of cruft in the commit messages. 