### PR TITLE
Migrate spacer style from TT1 theme

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -244,3 +244,13 @@ h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
 	background: none;
 }
+
+/*--------------------------------------------------------------
+# Spacer
+--------------------------------------------------------------*/
+
+@media only screen and (max-width: 482px) {
+	.wp-block-spacer[style] {
+		height: var(--wp--custom--spacing--unit) !important;
+	}
+}


### PR DESCRIPTION
The following is to replicate the styles found in [/twentytwentyone/assets/sass/05-blocks/spacer/_style.scss
](https://github.com/WordPress/twentytwentyone/blob/trunk/assets/sass/05-blocks/spacer/_style.scss)

Where when in mobile width and the spacer has a style attribute assigned (assuringly for a height value)
	force the height of the spacer to whatever the global spacing unit is set to be.

CSS variables cannot be used for media queries

(an example that does not work...)
`@media only screen and (max-width: var(--wp--custom--spacing--mobile-breakpoint)) {`

I don't know of a configurable way to manage breakpoints with theme.json

I attempted to construct a possible implementation of those settings in the theme.json
file and couldn't figure out how it might work so I have no suggestions there.

What are we trying to define and allow a user to configure... and what do we just want to be a part of the theme's style?

The fact that the spacer collapses at a breakpoint?
At what breakpoint it collapses?
What height it should collapse to?

Or is it just an aspect of the theme, the already configured spacing unit is enough variance.

If it just belongs as CSS in the theme, how do we normalize the media query breakpoints?