### PR TITLE
TT1 Blocks: migrate table block styles

### DIFF
--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -244,3 +244,15 @@ h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 .wp-block-social-links.is-style-twentytwentyone-social-icons-color .wp-social-link {
 	background: none;
 }
+
+/*--------------------------------------------------------------
+# Table Block
+--------------------------------------------------------------*/
+
+.wp-block-table {
+	min-width: 240px;
+}
+
+.wp-block-table th, .wp-block-table td {
+	border-width: 0;
+}

--- a/twentytwentyone-blocks/assets/css/blocks.css
+++ b/twentytwentyone-blocks/assets/css/blocks.css
@@ -249,10 +249,6 @@ h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 # Table Block
 --------------------------------------------------------------*/
 
-.wp-block-table {
-	min-width: 240px;
-}
-
-.wp-block-table th, .wp-block-table td {
+.wp-block-table.is-style-stripes td {
 	border-width: 0;
 }


### PR DESCRIPTION
This PR adds the CSS needed to match the table block styles from TT1, addressing part of #131.

It does not address the calendar block which is included in TT1's table block styles but I think should be addressed in another PR. 

I would test the following use cases:
 
- With and without a heading 
- With stripes style variation
- With a background color

Note that this PR requires https://github.com/WordPress/gutenberg/pull/27628 to look fully correct. 