### PR TITLE
Empty Theme: Fixed alignfull rule causing a horizontal scroll

### DIFF
--- a/emptytheme/assets/alignments-front.css
+++ b/emptytheme/assets/alignments-front.css
@@ -74,6 +74,6 @@ body {
 	.wp-site-blocks .alignfull {
 		transform: translateX(0px);
 		width: 100%;
-		max-width: calc(100% + var(--wp--custom--margin--horizontal));
+		max-width: 100%;
 	}
 }

--- a/emptytheme/assets/alignments-front.css
+++ b/emptytheme/assets/alignments-front.css
@@ -73,7 +73,7 @@ body {
 
 	.wp-site-blocks .alignfull {
 		transform: translateX(0px);
-		width: 100% + var(--wp--custom--margin--horizontal));
+		width: 100%;
 		max-width: calc(100% + var(--wp--custom--margin--horizontal));
 	}
 }


### PR DESCRIPTION
Our default alignment rules were causing a horizontal scroll on fully aligned images. This PR changes the width value to fix this.

**Before:**

<img width="1670" alt="Screenshot 2020-12-10 at 10 01 43" src="https://user-images.githubusercontent.com/3593343/101750276-14690400-3acf-11eb-937c-2a8c1445f73c.png">


**After:** 


<img width="1663" alt="Screenshot 2020-12-10 at 10 01 52" src="https://user-images.githubusercontent.com/3593343/101750274-13d06d80-3acf-11eb-8ebd-48c4b6e49d09.png">