### PR TITLE
Twenty Twenty One Blocks: migrated Heading block styles

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -237,6 +237,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": 1.1
 			}
 		}
@@ -245,6 +246,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}
@@ -253,6 +255,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}
@@ -261,6 +264,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}
@@ -269,6 +273,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}
@@ -277,6 +282,7 @@
 		"styles": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"fontWeight": "var(--wp--preset--font-weight--light)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		}


### PR DESCRIPTION
Part of #82

Closes https://github.com/WordPress/theme-experiments/issues/97

Dependency: https://github.com/WordPress/gutenberg/pull/27639

This won't work without the GB PR that enables font weights for this block.

**Screenshots:**

<img width="697" alt="Screenshot 2020-12-10 at 11 27 04" src="https://user-images.githubusercontent.com/3593343/101760391-15a02e00-3adb-11eb-9c27-c714cce4071e.png">
