### PR TITLE
Empty Theme: Fix custom spacing entry in theme.json

### DIFF
--- a/emptytheme/experimental-theme.json
+++ b/emptytheme/experimental-theme.json
@@ -6,13 +6,13 @@
 				"link": true,
 				"palette": [ ]
 			},
+			"spacing": {
+				"customPadding": true
+			},
 			"typography": {
 				"customLineHeight": true,
 				"fontFamilies": [ ],
-				"fontSizes": [ ],
-				"spacing": {
-					"customPadding": true
-				}
+				"fontSizes": [ ]
 			},
 			"custom": {
 				"width": {


### PR DESCRIPTION
This was previously declared under "typography", which is incorrect. 😄 

This PR moves it up a level, so you should see it properly registered and reflected in the UI:

<img width="1439" alt="Screen Shot 2020-12-10 at 10 00 46 AM" src="https://user-images.githubusercontent.com/1202812/101789211-00bd9d80-3acf-11eb-93cd-b357b578ac8d.png">
