### PR TITLE
Migrate button styles into TT1-blocks

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -289,5 +289,16 @@
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
 		}
+	},
+	"core/button": {
+		"styles": {
+			"color": {
+				"background": "var(--wp--preset--color--gray)",
+				"text": "var(--wp--preset--color--green)"
+			},
+			"border": {
+				"size": 0
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### Adds color & radius configs for button
Adds the expected color and border default values for the theme based
on the 2020 theme and expected changes to Gutenberg.