### PR TITLE
TT1 blocks: move spacing section to proper place

### DIFF
--- a/twentytwentyone-blocks/experimental-theme.json
+++ b/twentytwentyone-blocks/experimental-theme.json
@@ -197,11 +197,10 @@
 						"fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
 						"slug": "hoefler-times-new-roman"
 					}
-				],
-				"spacing": {
-					"customPadding": true,
-					"units": [ "px", "em", "rem", "vh", "vw" ]
-				}
+				]
+			},
+			"spacing": {
+				"customPadding": true
 			},
 			"custom": {
 				"font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",


### PR DESCRIPTION
This PR moves the spacing section up one hierarchy level, as it lives alongside the typography and colors sections.

It also removes the `customUnits`. They aren't different from the defaults, hence are unnecessary.