### PR TITLE
Include templates in conversion

### DIFF
--- a/new-empty-theme.php
+++ b/new-empty-theme.php
@@ -86,7 +86,7 @@ class Generate_Theme {
 	function replace_theme_name($contents, $filename) {
 
 		// Replace only text files, skip png's and other stuff.
-		$valid_extensions = array( 'php', 'css', 'scss', 'js', 'txt' );
+		$valid_extensions = array( 'php', 'css', 'scss', 'js', 'txt', 'html' );
 		$valid_extensions_regex = implode( '|', $valid_extensions );
 		if ( ! preg_match( "/\.({$valid_extensions_regex})$/", $filename ) )
 			return $contents;
@@ -111,6 +111,12 @@ class Generate_Theme {
 
 		// Special treatment for functions.php
 		if ( 'functions.php' === $filename ) {
+			$contents = str_replace( $this->old_themeslug, $this->theme['functions_slug'], $contents );
+			return $contents;
+		}
+
+		// Special treatment for templates
+		if ( 'html' === substr($filename, strrpos($filename, '.') + 1) ) {
 			$contents = str_replace( $this->old_themeslug, $this->theme['functions_slug'], $contents );
 			return $contents;
 		}


### PR DESCRIPTION
Previously, themes created using this script would need to have template slug values changed manually for the "stock" content to show up.

This change includes .html files in the change from oldslug > newslug

Tested by creating a new theme using script and loading the theme.  Basic content was showing:

![image](https://user-images.githubusercontent.com/146530/102276442-c7cd6080-3ef4-11eb-8e39-b028e4a115b1.png)
