### PR TITLE
TT1 Blocks: Update alignment rules

### DIFF
--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -52,11 +52,9 @@ body {
 	margin-right: auto;
 }
 
-.wp-site-blocks .alignwide {
+.wp-site-blocks .wp-block-post-content .alignwide {
 	width: var(--wp--custom--responsive--alignwide-width);
 	max-width: 100%;
-	margin-left: auto;
-	margin-right: auto;
 }
 
 .aligncenter {

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -45,13 +45,17 @@ body {
 	padding: 0 var(--wp--custom--spacing--horizontal);
 }
 
-.wp-site-blocks > *:not(.wp-block-post-content):not(.alignfull),
-.wp-site-blocks .wp-block-post-content > *:not(.alignfull) {
-	max-width: var(--wp--custom--responsive--aligndefault-width);
+.wp-site-blocks * {
 	margin-left: auto;
 	margin-right: auto;
 }
 
+.wp-site-blocks > *:not(.wp-block-post-content):not(.alignfull):not(.alignwide),
+.wp-site-blocks .wp-block-post-content > *:not(.alignfull):not(.alignwide) {
+	max-width: var(--wp--custom--responsive--aligndefault-width);
+}
+
+.wp-site-blocks > .alignwide,
 .wp-site-blocks .wp-block-post-content .alignwide {
 	width: var(--wp--custom--responsive--alignwide-width);
 	max-width: 100%;

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -46,7 +46,7 @@ body {
 }
 
 .wp-site-blocks > *:not(.wp-block-post-content),
-.wp-site-blocks .wp-block-post-content > * {
+.wp-site-blocks .wp-block-post-content > *:not(.alignfull) {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 	margin-left: auto;
 	margin-right: auto;
@@ -57,25 +57,6 @@ body {
 	max-width: 100%;
 	margin-left: auto;
 	margin-right: auto;
-}
-
-.wp-site-blocks .alignfull {
-	transform: translateX(calc(0px - var(--wp--custom--spacing--horizontal)));
-	width: calc(100% + (2 * var(--wp--custom--spacing--horizontal)));
-	max-width: calc(100% + (2 * var(--wp--custom--spacing--horizontal)));
-	margin-left: 0;
-	margin-right: 0;
-	box-sizing: content-box;
-}
-
-.wp-site-blocks .wp-block-template-part.alignfull {
-	width: 100%;
-	max-width: 100%;
-}
-
-.wp-site-blocks .wp-block-columns.alignfull {
-	width: 100%;
-	max-width: 100%;
 }
 
 .aligncenter {
@@ -99,11 +80,5 @@ body {
 	.wp-site-blocks,
 	.wp-block-template-part.alignfull {
 		padding: 0;
-	}
-
-	.wp-site-blocks .alignfull {
-		transform: translateX(0px);
-		width: 100%;
-		max-width: 100%;
 	}
 }

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -50,7 +50,8 @@ body {
 	margin-right: auto;
 }
 
-.wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide) {
+.wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide):not([class$="__inner-container"]) {
+ {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -50,13 +50,11 @@ body {
 	margin-right: auto;
 }
 
-.wp-site-blocks > *:not(.wp-block-post-content):not(.alignfull):not(.alignwide),
-.wp-site-blocks .wp-block-post-content > *:not(.alignfull):not(.alignwide) {
+.wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide) {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 
-.wp-site-blocks .alignwide,
-.wp-site-blocks .wp-block-post-content .alignwide {
+.wp-site-blocks .alignwide {
 	width: var(--wp--custom--responsive--alignwide-width);
 	max-width: 100%;
 }

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -45,7 +45,7 @@ body {
 	padding: 0 var(--wp--custom--spacing--horizontal);
 }
 
-.wp-site-blocks > *:not(.wp-block-post-content),
+.wp-site-blocks > *:not(.wp-block-post-content):not(.alignfull),
 .wp-site-blocks .wp-block-post-content > *:not(.alignfull) {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 	margin-left: auto;

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -55,7 +55,7 @@ body {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 
-.wp-site-blocks > .alignwide,
+.wp-site-blocks .alignwide,
 .wp-site-blocks .wp-block-post-content .alignwide {
 	width: var(--wp--custom--responsive--alignwide-width);
 	max-width: 100%;

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -51,7 +51,6 @@ body {
 }
 
 .wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide):not([class$="__inner-container"]) {
- {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -73,10 +73,6 @@ body {
 	max-width: 360px;
 }
 
-@media screen and (min-width: 1290px) {
-
-	.wp-site-blocks,
-	.wp-block-template-part.alignfull {
-		padding: 0;
-	}
+.wp-site-blocks .alignfull {
+	margin: 0 calc(0px - var(--wp--custom--spacing--horizontal));
 }


### PR DESCRIPTION
This is an attempt to simplify our alignment rules. Since blocks are `display: block` they will already take up 100% width. We only need to add margins when a block is _not_ alignfull.

Why wont this work?