### PR TITLE
TT1 Blocks: Update separator alignment rules

### DIFF
--- a/tt1-blocks/assets/css/blocks.css
+++ b/tt1-blocks/assets/css/blocks.css
@@ -190,9 +190,12 @@ hr:not(.is-style-wide):not(.is-style-dots),
 }
 
 .wp-block[data-align="wide"] .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
-.wp-block[data-align="full"] .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
 hr.alignwide:not(.is-style-wide):not(.is-style-dots),
-.wp-block-separator.alignwide:not(.is-style-wide):not(.is-style-dots),
+.wp-block-separator.alignwide:not(.is-style-wide):not(.is-style-dots) {
+	max-width: 100%;
+}
+
+.wp-block[data-align="full"] .wp-block-separator:not(.is-style-wide):not(.is-style-dots),
 hr.alignfull:not(.is-style-wide):not(.is-style-dots),
 .wp-block-separator.alignfull:not(.is-style-wide):not(.is-style-dots) {
 	max-width: inherit;
@@ -205,6 +208,10 @@ hr.is-style-twentytwentyone-separator-thick,
 
 .wp-block-separator.is-style-dots {
 	border-bottom: none;
+}
+
+.wp-block-separator.is-style-dots.alignwide {
+	width: 100%;
 }
 
 .wp-block-separator.is-style-dots > hr {


### PR DESCRIPTION
The separator block's custom alignment rules are sort of broken. This makes some small adjustments to get them working again. 

Desktop:

- Wide dots separator was misaligned.

Before|After
---|---
![Screen Shot 2020-12-18 at 3 52 53 PM](https://user-images.githubusercontent.com/1202812/102660555-360a6100-4149-11eb-81f4-a2a2ab1f77a4.png)|![Screen Shot 2020-12-18 at 3 51 06 PM](https://user-images.githubusercontent.com/1202812/102660558-373b8e00-4149-11eb-9999-048755809437.png)

Mobile:

- Wide separator went offscreen on the right. 
- Wide dots separator went offscreen too.

Before|After
---|---
![Screen Shot 2020-12-18 at 3 53 08 PM](https://user-images.githubusercontent.com/1202812/102660574-3e629c00-4149-11eb-9584-f60ffc218a17.png)|![Screen Shot 2020-12-18 at 3 51 25 PM](https://user-images.githubusercontent.com/1202812/102660579-3f93c900-4149-11eb-9a91-f4bb18ddd763.png)

