### PR TITLE
TT1 Blocks -Add query pagination

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -1,7 +1,6 @@
 <!-- wp:template-part {"slug":"header","theme":"tt1-blocks","align":"full", "tagName":"header","className":"site-header"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-
+<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
 
 <!-- wp:query-loop -->
 <!-- wp:post-title {"isLink":true} /-->
@@ -35,6 +34,7 @@
 <!-- /wp:spacer -->
 
 <!-- /wp:query-loop -->
+<!-- wp:query-pagination /-->
 <!-- /wp:query -->
 
 <!-- wp:template-part {"slug":"footer","theme":"tt1-blocks","align":"full","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-experiments/issues/158

Adds the query pagination block to index.php.
Updates the query page setting to 100 so that there are pages of results to show 
(It is not possible to select for example  -1 to display all existing results).