### PR TITLE
TT1 Blocks: Version bump, remove accessibility-ready tag

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -23,7 +23,7 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
-= 0.3 =
+= 0.4 =
 * Released: January 11, 2021
 
 Initial release

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -7,11 +7,11 @@ Description: TT1 Blocks is a block-based version of the default Twenty Twenty-On
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.3
+Version: 0.4
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks
-Tags: one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready
 
 TT1 Blocks WordPress Theme, (C) 2020 WordPress.org
 TT1 Blocks is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
Since block-based themes can't conform to those `accessibility-ready` standards yet.

_Ref:_ https://themes.trac.wordpress.org/ticket/93906