### PR TITLE
TT1 Blocks: Version bump + update tags

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -23,7 +23,7 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
-= 0.4 =
+= 0.4.1 =
 * Released: January 11, 2021
 
 Initial release

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -7,11 +7,11 @@ Description: TT1 Blocks is a block-based version of the default Twenty Twenty-On
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.4
+Version: 0.4.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments
 
 TT1 Blocks WordPress Theme, (C) 2020 WordPress.org
 TT1 Blocks is distributed under the terms of the GNU GPL.


### PR DESCRIPTION
As per @carolinan's notes [on slack](https://wordpress.slack.com/archives/C02RP4VMP/p1610620845005800): 

> But there are actually other tags that are incorrect as well. footer-widgets, translation-ready are not available in FSE.
> The theme needs to have the full-site-editing tag because it is used to filter the themes in the theme directory.

This PR removes those two tags, and adds the full-site editing tag. 

It also bumps the version number so we can submit this to the theme repo. Rather than do a whole point release, I've changed this to 0.4.1... That way it'll be a while before we hit 1.0. 😄
