### PR TITLE
TT1 Blocks: Fix short theme description and date.

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -7,6 +7,8 @@ Stable tag: 0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
+TT1 Blocks is an experimental block-based version of the Twenty Twenty-One theme. It is built to leverage the full-site editing functionality that is being built in the Gutenberg plugin. This theme is not meant for use on a production site.
+
 == Description ==
 
 TT1 Blocks is a fully block-based version the <a href="https://wordpress.org/themes/twentytwentyone/">Twenty Twenty-One</a> theme. It is built to leverage the full-site editing functionality that is being built in the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg plugin</a>. This work is ongoing, and updates are available on the <a href="https://make.wordpress.org/core/?s=gutenberg">Make WordPress Core blog</a>.
@@ -23,8 +25,8 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
-= 0.4.1 =
-* Released: January 11, 2021
+= 0.4.2 =
+* Released: January 14, 2021
 
 Initial release
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -3,11 +3,11 @@ Theme Name: TT1 Blocks
 Theme URI: https://github.com/WordPress/theme-experiments/tree/master/tt1-blocks
 Author: the WordPress team
 Author URI: https://wordpress.org/
-Description: TT1 Blocks is a block-based version of the default Twenty Twenty-One theme. It's just like Twenty Twenty-One, but it works with the experimental Full-Site Editing & Global Styles features of WordPress.
+Description: TT1 Blocks is an experimental block-based version of the Twenty Twenty-One theme. It is built to leverage the full-site editing functionality that is being built in the Gutenberg plugin. This theme is not meant for use on a production site.
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.4.1
+Version: 0.4.2
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks


### PR DESCRIPTION
The theme description in the repo was pulling from the one in `style.css`, which didn't sync up with the one in the readme.txt. This cleans that up. 

It also changes the release date to today, which is the actual date the theme was released.