### PR TITLE
TT1 Blocks: Fix frontend full alignment styles

### DIFF
--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -50,7 +50,7 @@ body {
 	margin-right: auto;
 }
 
-.wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide):not([class$="__inner-container"]) {
+.wp-site-blocks *:not(.wp-block-post-content):not(.alignfull):not(.alignwide):not([class$="__inner-container"]):not(img) {
 	max-width: var(--wp--custom--responsive--aligndefault-width);
 }
 
@@ -77,4 +77,5 @@ body {
 
 .wp-site-blocks .alignfull {
 	margin: 0 calc(0px - var(--wp--custom--spacing--horizontal));
+	width: calc(100% + (2 - var(--wp--custom--spacing--horizontal)));
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/theme-experiments/issues/170

The `max-width` limit here should not override the width of images here, since they should generally be the width of their `figure` or cover containers. 

Separately, we weren't specifying a `max-width` for `alignfull`, which means that they were maxing out at `100%` by default and not taking into account the left/right padding on the container. 

## Screenshots

Before

![Screen Shot 2021-01-22 at 9 08 51 AM](https://user-images.githubusercontent.com/1202812/105503406-87e85e80-5c94-11eb-8b89-070abe7557d1.png)

After

![Screen Shot 2021-01-22 at 9 23 23 AM](https://user-images.githubusercontent.com/1202812/105503415-8a4ab880-5c94-11eb-953b-9d22ae404a04.png)
