### PR TITLE
Updates to theme.json

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,6 +1,6 @@
 {
 	"settings": {
-		"*": {
+		"global": {
 			"color": {
 				"palette": [
 					{
@@ -222,7 +222,7 @@
 		}
 	},
 	"styles": {
-		"root": {
+		"global": {
 			"color": {
 				"background": "var(--wp--preset--color--green)",
 				"text": "var(--wp--preset--color--dark-gray)",

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,6 +1,6 @@
 {
 	"settings": {
-		"global": {
+		"*": {
 			"color": {
 				"palette": [
 					{
@@ -222,7 +222,7 @@
 		}
 	},
 	"styles": {
-		"global": {
+		"root": {
 			"color": {
 				"background": "var(--wp--preset--color--green)",
 				"text": "var(--wp--preset--color--dark-gray)",

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,6 +1,6 @@
 {
-	"global": {
-		"settings": {
+	"settings": {
+		"global": {
 			"color": {
 				"palette": [
 					{
@@ -219,9 +219,11 @@
 					"vertical": "30px"
 				}
 			}
-		},
-		"styles": {
-	    	"color": {
+		}
+	},
+	"styles": {
+		"global": {
+			"color": {
 				"background": "var(--wp--preset--color--green)",
 				"text": "var(--wp--preset--color--dark-gray)",
 				"link": "var(--wp--preset--color--dark-gray)"
@@ -230,97 +232,73 @@
 				"fontSize": "var(--wp--preset--font-size--normal)",
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
-		}
-	},
-	"core/heading/h1": {
-		"styles": {
+		},
+		"core/heading/h1": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
 				"lineHeight": 1.1
 			}
-		}
-	},
-	"core/heading/h2": {
-		"styles": {
+		},
+		"core/heading/h2": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
-		}
-	},
-	"core/heading/h3": {
-		"styles": {
+		},
+		"core/heading/h3": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
-		}
-	},
-	"core/heading/h4": {
-		"styles": {
+		},
+		"core/heading/h4": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
-		}
-	},
-	"core/heading/h5": {
-		"styles": {
+		},
+		"core/heading/h5": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
-		}
-	},
-	"core/heading/h6": {
-		"styles": {
+		},
+		"core/heading/h6": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
-		}
-	},
-	"core/site-tagline": {
-		"styles": {
+		},
+		"core/site-tagline": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
 				"lineHeight": 1.4
 			}
-		}
-	},
-	"core/site-title": {
-		"styles": {
+		},
+		"core/site-title": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)"
 			}
-		}
-	},
-	"core/post-author": {
-		"styles": {
+		},
+		"core/post-author": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
-		}
-	},
-	"core/post-date": {
-		"styles": {
+		},
+		"core/post-date": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
-		}
-	},
-	"core/post-hierarchical-terms": {
-		"styles": {
+		},
+		"core/post-hierarchical-terms": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
-		}
-	},
-	"core/post-tags": {
-		"styles": {
+		},
+		"core/post-tags": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--body)"

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,6 +1,6 @@
 {
 	"settings": {
-		"global": {
+		"defaults": {
 			"color": {
 				"palette": [
 					{
@@ -222,7 +222,7 @@
 		}
 	},
 	"styles": {
-		"global": {
+		"root": {
 			"color": {
 				"background": "var(--wp--preset--color--green)",
 				"text": "var(--wp--preset--color--dark-gray)",


### PR DESCRIPTION
Superseedes https://github.com/WordPress/theme-experiments/pull/175

This PR updates the theme.json to the latest format, according to the two PRs that landed in Gutenberg recently:

- WordPress/gutenberg#28533
- https://github.com/WordPress/gutenberg/pull/28110

How was the format before those PR landed:

```json
{
  "global": {
    "settings": { ... },
    "styles": { ... }
  },
  "core/paragraph": {
    "settings": { ... },
    "styles": { ... }
  }
}
``` 

How it's now:

```json
{
  "settings": {
    "defaults": { ... },
    "root": { ... },
    "core/paragraph": { ... }
  },
  "styles": {
    "root": { ... },
    "core/paragraph": { ... }
  }
}
```

There's more [details and info in the docs](https://developer.wordpress.org/block-editor/developers/themes/theme-json/).