### PR TITLE
TT1 Blocks: Bump the version up to 0.4.3

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -25,6 +25,9 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
+= 0.4.3 =
+* Update for compatibility with Gutenberg v9.9
+
 = 0.4.2 =
 * Released: January 14, 2021
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -7,7 +7,7 @@ Description: TT1 Blocks is an experimental block-based version of the Twenty Twe
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.4.2
+Version: 0.4.3
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks


### PR DESCRIPTION
Now that the `theme.json` format and other template updates have been merged in, I suggest we increase the version number on the theme. 

Once Gutenberg 9.9 is officially published, we can then push this live in the Theme Directory too. 