### PR TITLE
TT1 Blocks: Use line height variable for H1

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -236,7 +236,7 @@
 		"core/heading/h1": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
-				"lineHeight": 1.1
+				"lineHeight": "var(--wp--custom--line-height--page-title)"
 			}
 		},
 		"core/heading/h2": {


### PR DESCRIPTION
This is minor, but: 

TT1 Blocks [defines a `var(--wp--custom--line-height--page-title)` variable](https://github.com/WordPress/theme-experiments/blob/f181c675b408e18cfcb9266fd475532d67125495/tt1-blocks/experimental-theme.json#L210), but does not use it. This PR changes a `1.1` line height value to that variable instead. 