### PR TITLE
TT1 Blocks: allow custom font overrides

### DIFF
--- a/tt1-blocks/assets/css/style-shared.css
+++ b/tt1-blocks/assets/css/style-shared.css
@@ -8,6 +8,10 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
+h1, h2, h3, h4, h5, h6 {
+	font-family: var(--wp--custom--font-secondary), var(--wp--custom--font-primary);
+}
+
 /*
  * text-underline-offset doesn't work in Chrome at all 👎
  * But looks nice in Safari/Firefox, so let's keep it and
@@ -25,7 +29,7 @@ a:hover {
 }
 
 /*
- * Gutenberg remotes this underline, but Twenty Twenty-One uses it. 
+ * Gutenberg remotes this underline, but Twenty Twenty-One uses it.
  */
 .site-header h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 	text-decoration: underline;

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -203,7 +203,8 @@
 				"customPadding": true
 			},
 			"custom": {
-				"font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+				"font-primary": "var(--font-base, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif)",
+				"font-secondary": "var(--font-headings, --wp--custom--font-primary)",
 				"line-height": {
 					"body": 1.7,
 					"heading": 1.3,


### PR DESCRIPTION
Hi, I'm back again! This is nearly/exactly identical to #183 and will unblock broader testing of this theme on WordPress.com, where we allow font customizations. 

This will allow base fonts to be overridden by supplying the `--font-base` CSS custom property on `:root`
and headings to alternately be overridden by `--font-headings`, falling back to the base font if not supplied.

The current goal is to enable customization in the Gutenboarding flow on WordPress.com, and will fix the issue
of it not working detailed at https://github.com/Automattic/wp-calypso/issues/48973

Testing should simply be that nothing is changed by default. You can use your inspector to add custom properties. If you add `--font-base` to the `html` element, you should see all of the fonts change to render with that value (allowing a single font for the whole theme, as is currently the case), and adding `--font-headings` should switch all headings to that value. 

Eg, with `--font-base` set to `Georgia`:
<img width="925" alt="image" src="https://user-images.githubusercontent.com/195089/106189765-5547d580-616e-11eb-9076-ea1744f6f09d.png">

`--font-base: Georgia; --font-headings: Verdana;` 👍 
<img width="878" alt="image" src="https://user-images.githubusercontent.com/195089/106189940-8b855500-616e-11eb-9f20-45505af45885.png">

