### PR TITLE
Block based themes - Add template part section info to theme JSON files.

### DIFF
--- a/gutenberg-starter-theme-blocks/experimental-theme.json
+++ b/gutenberg-starter-theme-blocks/experimental-theme.json
@@ -1,10 +1,10 @@
 {
 	"templateParts": {
 		"header": {
-			"section": "header"
+			"area": "header"
 		},
 		"footer": {
-			"section": "footer"
+			"area": "footer"
 		}
 	},
 	"global": {

--- a/gutenberg-starter-theme-blocks/experimental-theme.json
+++ b/gutenberg-starter-theme-blocks/experimental-theme.json
@@ -1,4 +1,12 @@
 {
+	"templateParts": {
+		"header": {
+			"section": "header"
+		},
+		"footer": {
+			"section": "footer"
+		}
+	},
 	"global": {
 		"presets": {
 			"color": [

--- a/photo-blocks/experimental-theme.json
+++ b/photo-blocks/experimental-theme.json
@@ -1,4 +1,15 @@
 {
+	"templateParts": {
+		"header": {
+			"section": "header"
+		},
+		"footer": {
+			"section": "footer"
+		},
+		"post-grid": {
+			"section": "uncategorized"
+		}
+	},
 	"global": {
 		"settings": {
 			"color": {

--- a/photo-blocks/experimental-theme.json
+++ b/photo-blocks/experimental-theme.json
@@ -1,13 +1,13 @@
 {
 	"templateParts": {
 		"header": {
-			"section": "header"
+			"area": "header"
 		},
 		"footer": {
-			"section": "footer"
+			"area": "footer"
 		},
 		"post-grid": {
-			"section": "uncategorized"
+			"area": "uncategorized"
 		}
 	},
 	"global": {

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,4 +1,12 @@
 {
+	"templateParts": {
+		"header": {
+			"section": "header"
+		},
+		"footer": {
+			"section": "footer"
+		}
+	},
 	"settings": {
 		"defaults": {
 			"color": {

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,10 +1,10 @@
 {
 	"templateParts": {
 		"header": {
-			"section": "header"
+			"area": "header"
 		},
 		"footer": {
-			"section": "footer"
+			"area": "footer"
 		}
 	},
 	"settings": {

--- a/twentytwenty-blocks/experimental-theme.json
+++ b/twentytwenty-blocks/experimental-theme.json
@@ -1,10 +1,10 @@
 {
 	"templateParts": {
 		"header": {
-			"section": "header"
+			"area": "header"
 		},
 		"footer": {
-			"section": "footer"
+			"area": "footer"
 		}
 	},
 	"global": {

--- a/twentytwenty-blocks/experimental-theme.json
+++ b/twentytwenty-blocks/experimental-theme.json
@@ -1,4 +1,12 @@
 {
+	"templateParts": {
+		"header": {
+			"section": "header"
+		},
+		"footer": {
+			"section": "footer"
+		}
+	},
 	"global": {
 		"presets": {
 			"color": [


### PR DESCRIPTION
Goes along with - https://github.com/WordPress/gutenberg/pull/28410 - to declare the JSON info for template part sections.  This will aid in allowing themes to supply the default taxonomy term used for enabling semantic/categorized template part flows.