### PR TITLE
Rename pageTemplates to customTemplates

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -305,7 +305,7 @@
 			}
 		}
 	},
-	"pageTemplates": {
+	"customTemplates": {
 		"page-home": {
 			"title": "Page without title"
 		}


### PR DESCRIPTION
Updates the key used to declared custom templates as per https://github.com/WordPress/gutenberg/pull/28830