### PR TITLE
TT1-Blocks: Fix full width alignment for page-home post content

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -9,7 +9,7 @@
 		<!-- wp:query-loop -->
 		<!-- wp:post-title {"isLink":true} /-->
 
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"align":"full"} /-->
 
 		<!-- wp:spacer {"height":70} -->
 		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/tt1-blocks/block-templates/page-home.html
+++ b/tt1-blocks/block-templates/page-home.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main", "align":"full"} -->
 <main class="wp-block-group alignfull">
 	<div class="wp-block-group__inner-container">
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"align":"full"} /-->
 	</div>
 </main>
 <!-- /wp:group -->

--- a/tt1-blocks/block-templates/page.html
+++ b/tt1-blocks/block-templates/page.html
@@ -13,7 +13,7 @@
 		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"align":"full"} /-->
 		<!-- wp:post-comments /-->
 		<!-- wp:post-comments-form /-->
 	</div>

--- a/tt1-blocks/block-templates/single.html
+++ b/tt1-blocks/block-templates/single.html
@@ -13,7 +13,7 @@
 		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
 
-		<!-- wp:post-content /-->
+		<!-- wp:post-content {"align":"full"} /-->
 
 		<!-- wp:spacer {"height":70} -->
 		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
## Description
On initial creation, the `page-home` template appears to have content that doesn't respect `wide width` or `full width` alignment.

<img width="1680" alt="Screenshot 2021-02-01 at 23 31 04" src="https://user-images.githubusercontent.com/1182160/106526374-c75d4900-64e5-11eb-86d9-05117da59bf4.png">

## Screenshots

## Testing
- Spin up the site editor locally
- Activate the tt1-blocks theme
- Navigate to the site editor
- Select the `page-home` template to display
- Find the post content block and click on it
- Verify that the alignment defaults to "full"