### PR TITLE
Experiment to add Color Customizer Controls to TT1-Blocks

### DIFF
--- a/tt1-blocks/assets/classes/customizer-bridge.php
+++ b/tt1-blocks/assets/classes/customizer-bridge.php
@@ -33,7 +33,7 @@ class CustomizerBridge {
 				$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer-bridge-' . $custom_option->slug ) . ';';
 			}
 		}
-		$css_variables = $css_variables . ';}';
+		$css_variables = $css_variables . '}';
 
 		return $css_variables;
 	}
@@ -47,59 +47,68 @@ class CustomizerBridge {
 		// Add Color Controls
 		foreach ($this->theme_customizations as $custom_section) {
 
-			if ( 'section' === $custom_section->type ) {
+			if ('section' === $custom_section->type) {
 
-			$section_key = 'customizer-bridge-'.$custom_section->slug;
+				$section_key = 'customizer-bridge-' . $custom_section->slug;
 
-			//Add a Section to the Customizer for these bits
-			$wp_customize->add_section(
-				$section_key,
-				array(
-					'capability' => 'edit_theme_options',
-					'title'      => esc_html__( $custom_section->name, 'customizer-bridge' ),
-				)
-			);
-
-			$wp_customize->get_section( $section_key ) -> description = __( $custom_section->description );
-
-
-		// Add Color Controls
-		foreach ($custom_section->controls as $custom_option) {
-
-			$setting_key = 'customizer-bridge-' . $custom_option->slug;
-
-			if ( 'color' === $custom_option->type ) {
-
-				$wp_customize->add_setting(
-					$setting_key,
+				//Add a Section to the Customizer for these bits
+				$wp_customize->add_section(
+					$section_key,
 					array(
-						'default'           => esc_html( $custom_option->default ),
-						'sanitize_callback' => 'sanitize_hex_color',
+						'capability' => 'edit_theme_options',
+						'title'      => esc_html__($custom_section->name, 'customizer-bridge'),
 					)
 				);
 
-				$wp_customize->add_control(
-					new WP_Customize_Color_Control(
-						$wp_customize,
-						$setting_key,
-						array(
-							'section' => $section_key,
-							'label'   => $custom_option->name,
-						)
-					)
-				);
+				$wp_customize->get_section($section_key)->description = __($custom_section->description);
 
+
+				// Add Controls
+				foreach ($custom_section->controls as $custom_option) {
+
+					$setting_key = 'customizer-bridge-' . $custom_option->slug;
+
+					if ('color' === $custom_option->type) {
+
+						$wp_customize->add_setting(
+							$setting_key,
+							array(
+								'default'           => esc_html($custom_option->default),
+								'sanitize_callback' => 'sanitize_hex_color',
+							)
+						);
+
+						$wp_customize->add_control(
+							new WP_Customize_Color_Control(
+								$wp_customize,
+								$setting_key,
+								array(
+									'section' => $section_key,
+									'label'   => $custom_option->name,
+								)
+							)
+						);
+					}
+
+					elseif ('boolean' === $custom_option->type) {
+
+						$wp_customize->add_setting( $setting_key );
+						$wp_customize->add_control(
+							$setting_key,
+							array(
+								'label'       => esc_html__( $custom_option->name ),
+								'description' => $custom_option->description,
+								'section'     => $section_key,
+								'type'        => 'checkbox',
+								'settings'	  => $setting_key
+							)
+						);
+
+					}
+
+				}
 			}
 		}
-
-
-		}
-
-		}
-
-
-
-		// TODO: Add other types of controls
 
 	}
 

--- a/tt1-blocks/assets/classes/customizer-bridge.php
+++ b/tt1-blocks/assets/classes/customizer-bridge.php
@@ -29,7 +29,7 @@ class CustomizerBridge {
 
 		$css_variables = ':root {';
 		foreach ($this->theme_customizations as $custom_option) {
-			$css_variables = $css_variables . '--wp--custom--customizer--' . $custom_option->slug . ':' . get_theme_mod( 'customizer_' . $custom_option->slug ) . ';';
+			$css_variables = $css_variables . '--wp--custom--' . $custom_option->slug . ':' . get_theme_mod( 'customizer_' . $custom_option->slug ) . ';';
 		}
 		$css_variables = $css_variables . ';}';
 

--- a/tt1-blocks/assets/classes/customizer-bridge.php
+++ b/tt1-blocks/assets/classes/customizer-bridge.php
@@ -1,0 +1,88 @@
+<?php 
+class CustomizerBridge {
+
+	private $theme_customizations;
+
+	function __construct() {
+		add_action( 'customize_register', array( $this, 'customizer_bridge_register' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'customizer_bridge_output_variables' ) );
+		$this->theme_customizations = $this->get_theme_customizations();
+	}
+
+	function get_theme_customizations() {
+		$string = file_get_contents( get_stylesheet_directory() . "/experimental-theme.json");
+		$decoded = json_decode ( $string );
+		return $decoded->settings->defaults->custom_meta;
+	}
+
+	/**
+	 * Enqueue color variables for customizer & frontend.
+	 */
+	function customizer_bridge_output_variables() {
+		wp_add_inline_style( 'customizer-style', $this->customizer_bridge_generate_custom_color_variables() );
+	}
+
+	/**
+	 * Render the customized variables.
+	 */
+	function customizer_bridge_generate_custom_color_variables ( $context=null ) {
+
+		$css_variables = ':root {';
+		foreach ($this->theme_customizations as $custom_option) {
+			$css_variables = $css_variables . '--wp--custom--customizer--' . $custom_option->slug . ':' . get_theme_mod( 'customizer_' . $custom_option->slug ) . ';';
+		}
+		$css_variables = $css_variables . ';}';
+
+		return $css_variables;
+	}
+
+	/**
+	 * Use theme.json to determine what variables to provide dials for.
+	 * Add those dials to the customizer interface.
+	 */
+	function customizer_bridge_register( $wp_customize ) {
+
+		//Add a Section to the Customizer for these bits
+		$wp_customize->add_section(
+			'customizer_bridge_options',
+			array(
+				'capability' => 'edit_theme_options',
+			    'title'      => esc_html__( 'JSON Options', 'customizer-bridge' ),
+			)
+		);
+		$wp_customize->get_section( 'customizer_bridge_options' ) ->description = __( 'This section of the customizer allows for customization of things defined in theme.json.' );
+
+
+		// Add Color Controls
+		foreach ($this->theme_customizations as $custom_option) {
+
+			if ( 'color' !== $custom_option->type ) {
+				break;
+			}
+
+			$wp_customize->add_setting(
+				'customizer_' . $custom_option->slug,
+				array(
+					'default'           => esc_html( $custom_option->default ),
+					'sanitize_callback' => 'sanitize_hex_color',
+				)
+			);
+
+			$wp_customize->add_control(
+				new WP_Customize_Color_Control(
+					$wp_customize,
+					'customizer_' . $custom_option->slug,
+					array(
+						'section' => 'customizer_bridge_options',
+						'label'   => $custom_option->name,
+					)
+				)
+			);
+		}
+
+		// TODO: Add other types of controls
+
+	}
+
+}
+new CustomizerBridge; 

--- a/tt1-blocks/assets/css/noop.css
+++ b/tt1-blocks/assets/css/noop.css
@@ -1,0 +1,3 @@
+/*
+This is an empty CSS file that is used to enque the customizer styles.
+*/

--- a/tt1-blocks/assets/css/variables-dark.css
+++ b/tt1-blocks/assets/css/variables-dark.css
@@ -1,0 +1,7 @@
+@media ( prefers-color-scheme: dark ) {
+	:root {
+		--wp--custom--color--background: var(--wp--preset--color--dark-gray);
+		--wp--custom--color--foreground: var(--wp--preset--color--light-gray);
+		--wp--custom--color--primary: var(--wp--preset--color--light-gray);
+	}
+}

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -232,7 +232,7 @@
 				{
 					"name": "Background Color",
 					"type": "color",
-					"default": "var(--wp--preset--color--green)",
+					"default": "#D1E4DD",
 					"slug": "color--background"
 				}
 			]

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -217,16 +217,33 @@
 					"unit": "20px",
 					"horizontal": "25px",
 					"vertical": "30px"
+				},
+				"color": {
+					"primary": "var(--wp--preset--color--dark-gray)",
+					"secondary": "var(--wp--preset--color--dark-gray)",
+					"foreground": "var(--wp--preset--color--dark-gray)",
+					"background": "var(--wp--preset--color--green)"
+				},
+				"dark": {
+					"enabled": "false"
 				}
-			}
+			},
+			"custom_meta": [
+				{
+					"name": "Background Color",
+					"type": "color",
+					"default": "var(--wp--preset--color--green)",
+					"slug": "color--background"
+				}
+			]
 		}
 	},
 	"styles": {
 		"root": {
 			"color": {
-				"background": "var(--wp--preset--color--green)",
-				"text": "var(--wp--preset--color--dark-gray)",
-				"link": "var(--wp--preset--color--dark-gray)"
+				"background": "var(--wp--custom--color--background)",
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--custom--color--primary)"
 			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--normal)",
@@ -234,36 +251,60 @@
 			}
 		},
 		"core/heading/h1": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
 				"lineHeight": "var(--wp--custom--line-height--page-title)"
 			}
 		},
 		"core/heading/h2": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h3": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h4": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h5": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h6": {
+			"color": {
+				"text": "var(--wp--custom--color--foreground)",
+				"link": "var(--wp--preset--color--primary)"
+			},
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)"

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -14,6 +14,11 @@
 						"name": "Dark Gray"
 					},
 					{
+						"slug": "light-gray",
+						"color": "#f0f0f0",
+						"name": "Light Gray"
+					},
+					{
 						"slug": "gray",
 						"color": "#39414D",
 						"name": "Gray"
@@ -245,7 +250,8 @@
 							"name": "Dark Mode support",
 							"type": "boolean",
 							"default": false,
-							"slug": "dark--enabled"
+							"slug": "dark--enabled",
+							"description": "Dark Mode is a device setting. If a visitor to your site requests it, your site will be shown with a dark background and light text. Learn more about Dark Mode. Dark Mode can also be turned on and off with a button that you can find in the bottom right corner of the page."
 						}
 					]
 				}

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -230,10 +230,24 @@
 			},
 			"custom_meta": [
 				{
-					"name": "Background Color",
-					"type": "color",
-					"default": "#D1E4DD",
-					"slug": "color--background"
+					"name": "Colors & Dark Mode",
+					"type": "section",
+					"slug": "colors",
+					"description": "This is a section of the customizer that allows for customization of things defined in theme.json.",
+					"controls": [
+						{
+							"name": "Background Color",
+							"type": "color",
+							"default": "#D1E4DD",
+							"slug": "color--background"
+						},
+						{
+							"name": "Dark Mode support",
+							"type": "boolean",
+							"default": false,
+							"slug": "dark--enabled"
+						}
+					]
 				}
 			]
 		}

--- a/tt1-blocks/functions.php
+++ b/tt1-blocks/functions.php
@@ -57,169 +57,6 @@ if ( ! function_exists( 'tt1_blocks_setup' ) ) {
 			'./assets/css/style-editor.css', 
 		) );
 
-		// Add custom editor font sizes.
-		add_theme_support(
-			'editor-font-sizes',
-			array(
-				array(
-					'name'      => esc_html__( 'Extra small', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'XS', 'Font size', 'tt1-blocks' ),
-					'size'      => 16,
-					'slug'      => 'extra-small',
-				),
-				array(
-					'name'      => esc_html__( 'Small', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'S', 'Font size', 'tt1-blocks' ),
-					'size'      => 18,
-					'slug'      => 'small',
-				),
-				array(
-					'name'      => esc_html__( 'Normal', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'M', 'Font size', 'tt1-blocks' ),
-					'size'      => 20,
-					'slug'      => 'normal',
-				),
-				array(
-					'name'      => esc_html__( 'Large', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'L', 'Font size', 'tt1-blocks' ),
-					'size'      => 24,
-					'slug'      => 'large',
-				),
-				array(
-					'name'      => esc_html__( 'Extra Large', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'XL', 'Font size', 'tt1-blocks' ),
-					'size'      => 40,
-					'slug'      => 'extra-large',
-				),
-				array(
-					'name'      => esc_html__( 'Huge', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'XXL', 'Font size', 'tt1-blocks' ),
-					'size'      => 96,
-					'slug'      => 'huge',
-				),
-				array(
-					'name'      => esc_html__( 'Gigantic', 'tt1-blocks' ),
-					'shortName' => esc_html_x( 'XXXL', 'Font size', 'tt1-blocks' ),
-					'size'      => 144,
-					'slug'      => 'gigantic',
-				),
-			)
-		);
-
-		// Editor color palette.
-		$black     = '#000000';
-		$dark_gray = '#28303D';
-		$gray      = '#39414D';
-		$green     = '#D1E4DD';
-		$blue      = '#D1DFE4';
-		$purple    = '#D1D1E4';
-		$red       = '#E4D1D1';
-		$orange    = '#E4DAD1';
-		$yellow    = '#EEEADD';
-		$white     = '#FFFFFF';
-
-		add_theme_support(
-			'editor-color-palette',
-			array(
-				array(
-					'name'  => esc_html__( 'Black', 'tt1-blocks' ),
-					'slug'  => 'black',
-					'color' => $black,
-				),
-				array(
-					'name'  => esc_html__( 'Dark Gray', 'tt1-blocks' ),
-					'slug'  => 'dark-gray',
-					'color' => $dark_gray,
-				),
-				array(
-					'name'  => esc_html__( 'Gray', 'tt1-blocks' ),
-					'slug'  => 'gray',
-					'color' => $gray,
-				),
-				array(
-					'name'  => esc_html__( 'Green', 'tt1-blocks' ),
-					'slug'  => 'green',
-					'color' => $green,
-				),
-				array(
-					'name'  => esc_html__( 'Blue', 'tt1-blocks' ),
-					'slug'  => 'blue',
-					'color' => $blue,
-				),
-				array(
-					'name'  => esc_html__( 'Purple', 'tt1-blocks' ),
-					'slug'  => 'purple',
-					'color' => $purple,
-				),
-				array(
-					'name'  => esc_html__( 'Red', 'tt1-blocks' ),
-					'slug'  => 'red',
-					'color' => $red,
-				),
-				array(
-					'name'  => esc_html__( 'Orange', 'tt1-blocks' ),
-					'slug'  => 'orange',
-					'color' => $orange,
-				),
-				array(
-					'name'  => esc_html__( 'Yellow', 'tt1-blocks' ),
-					'slug'  => 'yellow',
-					'color' => $yellow,
-				),
-				array(
-					'name'  => esc_html__( 'White', 'tt1-blocks' ),
-					'slug'  => 'white',
-					'color' => $white,
-				),
-			)
-		);
-
-		add_theme_support(
-			'editor-gradient-presets',
-			array(
-				array(
-					'name'     => esc_html__( 'Purple to Yellow', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $purple . ', ' . $yellow . ')',
-					'slug'     => 'purple-to-yellow',
-				),
-				array(
-					'name'     => esc_html__( 'Yellow to Purple', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $purple . ')',
-					'slug'     => 'yellow-to-purple',
-				),
-				array(
-					'name'     => esc_html__( 'Green to Yellow', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $green . ', ' . $yellow . ')',
-					'slug'     => 'green-to-yellow',
-				),
-				array(
-					'name'     => esc_html__( 'Yellow to Green', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $green . ')',
-					'slug'     => 'yellow-to-green',
-				),
-				array(
-					'name'     => esc_html__( 'Red to Yellow', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $red . ', ' . $yellow . ')',
-					'slug'     => 'red-to-yellow',
-				),
-				array(
-					'name'     => esc_html__( 'Yellow to Red', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $yellow . ', ' . $red . ')',
-					'slug'     => 'yellow-to-red',
-				),
-				array(
-					'name'     => esc_html__( 'Purple to Red', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $purple . ', ' . $red . ')',
-					'slug'     => 'purple-to-red',
-				),
-				array(
-					'name'     => esc_html__( 'Red to Purple', 'tt1-blocks' ),
-					'gradient' => 'linear-gradient(160deg, ' . $red . ', ' . $purple . ')',
-					'slug'     => 'red-to-purple',
-				),
-			)
-		);
-
 		// Add support for responsive embedded content.
 		add_theme_support( 'responsive-embeds' );
 
@@ -241,6 +78,10 @@ add_action( 'after_setup_theme', 'tt1_blocks_setup' );
  */
 function tt1_blocks_scripts() {
 	wp_enqueue_style( 'tt1-blocks-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+
+	// Enqueue customizer bridge styles 
+	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array(), wp_get_theme()->get( 'Version' ) );
+
 }
 add_action( 'wp_enqueue_scripts', 'tt1_blocks_scripts' );
 
@@ -262,3 +103,6 @@ require get_template_directory() . '/inc/block-patterns.php';
 
 // Block Styles.
 require get_template_directory() . '/inc/block-styles.php';
+
+// Customizer Bridge
+require get_template_directory() . '/assets/classes/customizer-bridge.php';

--- a/tt1-blocks/functions.php
+++ b/tt1-blocks/functions.php
@@ -82,6 +82,10 @@ function tt1_blocks_scripts() {
 	// Enqueue customizer bridge styles 
 	wp_enqueue_style( 'customizer-style', get_template_directory_uri() . '/assets/css/noop.css', array(), wp_get_theme()->get( 'Version' ) );
 
+	if( true === get_theme_mod( 'customizer-bridge-dark--enabled', false ) ) {
+		wp_enqueue_style( 'tt1-variables-dark-style', get_stylesheet_directory_uri() . '/assets/css/variables-dark.css', array(), wp_get_theme()->get( 'Version' ) );
+	}
+
 }
 add_action( 'wp_enqueue_scripts', 'tt1_blocks_scripts' );
 


### PR DESCRIPTION
An experiment WIP to add Customizer Controls to TT1-Blocks

Background Color
![image](https://user-images.githubusercontent.com/146530/108018242-2ee6be80-6fe5-11eb-9b48-78078de8b852.png)

Dark Mode Support
![image](https://user-images.githubusercontent.com/146530/108018316-5fc6f380-6fe5-11eb-977d-4dd7ba96c2fe.png)

Experiment Goal: Show that a block-based theme can achieve feature-parity with a non-block based theme without a dependence on the Full Site Editor.

This will show that a theme built using primarily block-based tooling can achieve feature parity with an existing (classic) theme at the point of user customization.

In this way a new improved theme will be able to **take advantage of the FSE** rather than be **dependent on the FSE**.

This makes switching between themes, especially between FSE and non-FSE themes a consistent process;  There is a common denominator for all themes in this space.

The portions that are customizable could be surfaced in BOTH the Customizer (a common place for all themes) and the FSE.