### PR TITLE
Added (numerical) Font Weight Value to Headings

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -244,36 +244,42 @@
 		"core/heading/h1": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--page-title)"
 			}
 		},
 		"core/heading/h2": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h3": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h4": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h5": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h6": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
+				"fontWeight": 300,
 				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},


### PR DESCRIPTION
As a replacement for #135, this change adds font weights to the headers via theme.json via numerical values rather than CSS variables.

Closes #97 

This is necessary due to [this Gutenberg change](https://github.com/WordPress/gutenberg/pull/27555).

This change (as was the original) is still dependent on this Gutenberg change allowing the Heading block to adjust the font weight: https://github.com/WordPress/gutenberg/pull/27639
