### PR TITLE
TT1 Blocks: Bump version to 0.4.4

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -25,6 +25,9 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
+= 0.4.4 =
+* Update for compatibility with Gutenberg v10.0
+
 = 0.4.3 =
 * Update for compatibility with Gutenberg v9.9
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -7,7 +7,7 @@ Description: TT1 Blocks is an experimental block-based version of the Twenty Twe
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.4.3
+Version: 0.4.4
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks


### PR DESCRIPTION
Now that Gutenberg v10.0 is live in the plugin directory, I'd like to package up a new version of TT1 Blocks for submission to the Theme Repo. This PR just bumps the version to make that possible.

(Mostly because https://github.com/WordPress/theme-experiments/pull/202 is required to get the custom homepage template working in 10.0)