### PR TITLE
Empty Theme: Update copyright and author

### DIFF
--- a/emptytheme/style.css
+++ b/emptytheme/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Empty Theme
 Theme URI: https://github.com/wordpress/theme-experiments/
-Author: Kjell Reigstad
+Author: the WordPress team
 Description: The base for a block-based theme.
 Requires at least: 5.3
 Tested up to: 5.5
@@ -11,5 +11,6 @@ License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: emptytheme
 
+Empty Theme WordPress Theme, (C) 2021 WordPress.org
 Empty Theme is distributed under the terms of the GNU GPL.
 */


### PR DESCRIPTION
The copyright for this should be to WordPress.org, and I think the theme author should be the WordPress project now, not just me. This PR makes those changes. 