### PR TITLE
Empty Theme: Update license URI

### DIFF
--- a/emptytheme/style.css
+++ b/emptytheme/style.css
@@ -8,7 +8,7 @@ Tested up to: 5.5
 Requires PHP: 5.6
 Version: 1.0
 License: GNU General Public License v2 or later
-License URI: LICENSE
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: emptytheme
 
 Empty Theme WordPress Theme, (C) 2021 WordPress.org


### PR DESCRIPTION
It currently points to a LICENSE file that doesn't exist in the theme's directory. Seems simpler to just point to the GPL v2.0 URL. 