### PR TITLE
Site Title: Add settings to theme.json

### DIFF
--- a/tt1-blocks/assets/css/blocks.css
+++ b/tt1-blocks/assets/css/blocks.css
@@ -233,7 +233,6 @@ hr.is-style-twentytwentyone-separator-thick,
 
 h1.wp-block-site-title {
 	font-weight: var(--wp--custom--font-weight-normal);
-	text-transform: uppercase;
 }
 
 h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -272,6 +272,12 @@
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--body)"
 			}
+		},
+		"core/site-title": {
+			"typography": {
+				"fontSize": "var(--wp--preset--font-size--large)",
+				"textTransform": "uppercase"
+			}
 		}
 	},
 	"customTemplates": {


### PR DESCRIPTION
Now that [this](https://github.com/WordPress/gutenberg/pull/29622) Site Title PR has merged we can express the design of the Site Title block in theme.json:

<img width="1439" alt="Screenshot 2021-03-08 at 16 35 44" src="https://user-images.githubusercontent.com/275961/110351091-594bfa80-802c-11eb-9826-197495e063ee.png">

Fixes https://github.com/WordPress/theme-experiments/issues/163