### PR TITLE
TT1 Blocks: Update custom templates and template parts in the config

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -8,7 +8,7 @@
 			"name": "footer",
 			"area": "footer"
 		}
-	},
+	],
 	"settings": {
 		"defaults": {
 			"color": {

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -1,9 +1,11 @@
 {
-	"templateParts": {
-		"header": {
+	"templateParts": [
+		{
+			"name": "header",
 			"area": "header"
 		},
-		"footer": {
+		{
+			"name": "footer",
 			"area": "footer"
 		}
 	},
@@ -280,9 +282,10 @@
 			}
 		}
 	},
-	"customTemplates": {
-		"page-home": {
+	"customTemplates": [
+		{
+			"name": "page-home",
 			"title": "Page without title"
 		}
-	}
+	]
 }


### PR DESCRIPTION
Related to changes proposed in Gutenberg in https://github.com/WordPress/gutenberg/pull/29828.

There is going to be a bit different format for `customTemplates` and `templateParts`. The rationale behind it is that we want to align with other lists like font sizes, color palettes, or gradients. It should make it easier to write those configurations but it also will simplify the logic that handles translations.