### PR TITLE
TT1 Blocks Font Weight Value to Headings

### DIFF
--- a/tt1-blocks/assets/css/blocks.css
+++ b/tt1-blocks/assets/css/blocks.css
@@ -231,10 +231,14 @@ hr.is-style-twentytwentyone-separator-thick,
 # Site Title
 --------------------------------------------------------------*/
 
-h1.wp-block-site-title {
-	font-weight: var(--wp--custom--font-weight-normal);
-}
-
 h1.wp-block-site-title a:not(:hover):not(:focus):not(:active) {
 	text-decoration: none;
+}
+
+/*--------------------------------------------------------------
+# Single view Post Title
+--------------------------------------------------------------*/
+
+h1.wp-block-post-title {
+	font-weight: var(--wp--custom--font-weight--light);
 }

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -190,7 +190,7 @@
 					"vertical": "30px"
 				},
 				"font-weight":{
-					"title": "300"
+					"thin": "300"
 				}
 			}
 		}
@@ -211,42 +211,42 @@
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
 				"lineHeight": "var(--wp--custom--line-height--page-title)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/heading/h2": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/heading/h3": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/heading/h4": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/heading/h5": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/heading/h6": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--title)"
+				"fontWeight": "var(--wp--custom--font-weight--thin)"
 			}
 		},
 		"core/site-tagline": {

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -190,7 +190,8 @@
 					"vertical": "30px"
 				},
 				"font-weight":{
-					"thin": "300"
+					"light": "300",
+					"normal": "normal"
 				}
 			}
 		}
@@ -211,42 +212,39 @@
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
 				"lineHeight": "var(--wp--custom--line-height--page-title)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"fontWeight": "var(--wp--custom--font-weight--normal)"
 			}
 		},
 		"core/heading/h2": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"fontWeight": "var(--wp--custom--font-weight--normal)"
 			}
 		},
 		"core/heading/h3": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
 				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"fontWeight": "var(--wp--custom--font-weight--normal)"
 			}
 		},
 		"core/heading/h4": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
-				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h5": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
-				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/heading/h6": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
-				"lineHeight": "var(--wp--custom--line-height--heading)",
-				"fontWeight": "var(--wp--custom--font-weight--thin)"
+				"lineHeight": "var(--wp--custom--line-height--heading)"
 			}
 		},
 		"core/site-tagline": {
@@ -282,6 +280,7 @@
 		"core/site-title": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
+				"fontWeight": "var(--wp--custom--font-weight--normal)",
 				"textTransform": "uppercase"
 			}
 		}

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -188,6 +188,9 @@
 					"unit": "20px",
 					"horizontal": "25px",
 					"vertical": "30px"
+				},
+				"font-weight":{
+					"title": "300"
 				}
 			}
 		}
@@ -207,37 +210,43 @@
 		"core/heading/h1": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--gigantic)",
-				"lineHeight": "var(--wp--custom--line-height--page-title)"
+				"lineHeight": "var(--wp--custom--line-height--page-title)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/heading/h2": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-large)",
-				"lineHeight": "var(--wp--custom--line-height--heading)"
+				"lineHeight": "var(--wp--custom--line-height--heading)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/heading/h3": {
 			"typography": {
 				"fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
-				"lineHeight": "var(--wp--custom--line-height--heading)"
+				"lineHeight": "var(--wp--custom--line-height--heading)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/heading/h4": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--large)",
-				"lineHeight": "var(--wp--custom--line-height--heading)"
+				"lineHeight": "var(--wp--custom--line-height--heading)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/heading/h5": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--small)",
-				"lineHeight": "var(--wp--custom--line-height--heading)"
+				"lineHeight": "var(--wp--custom--line-height--heading)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/heading/h6": {
 			"typography": {
 				"fontSize": "var(--wp--preset--font-size--extra-small)",
-				"lineHeight": "var(--wp--custom--line-height--heading)"
+				"lineHeight": "var(--wp--custom--line-height--heading)",
+				"fontWeight": "var(--wp--custom--font-weight--title)"
 			}
 		},
 		"core/site-tagline": {


### PR DESCRIPTION
Alternative to #135 and #211, using a custom variable for the font weight for the title blocks.

Since https://github.com/WordPress/gutenberg/pull/29941, neither this PR or #211 relies on https://github.com/WordPress/gutenberg/pull/27639



