### PR TITLE
Small clean up for Empty theme

### DIFF
--- a/emptytheme/block-templates/index.html
+++ b/emptytheme/block-templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"emptytheme","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <!-- wp:query-loop -->

--- a/emptytheme/block-templates/singular.html
+++ b/emptytheme/block-templates/singular.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"emptytheme","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:post-title /-->
 

--- a/emptytheme/functions.php
+++ b/emptytheme/functions.php
@@ -6,9 +6,6 @@ if ( ! function_exists( 'emptytheme_support' ) ) :
 		// Adding support for featured images.
 		add_theme_support( 'post-thumbnails' );
 
-		// Adding support for alignwide and alignfull classes in the block editor.
-		add_theme_support( 'align-wide' );
-
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );
 


### PR DESCRIPTION
Removes `"theme":"emptytheme"` from wp:template-part to avoid template part not found messages.
Removes 	`add_theme_support( 'align-wide' );` that is not needed