### PR TITLE
Bump TT1 Blocks to version 4.4.5

### DIFF
--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -26,7 +26,7 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 == Changelog ==
 
 = 0.4.5 =
-* Update for compatibility with Gutenberg v10.1
+* Update for compatibility with Gutenberg v10.3
 
 = 0.4.4 =
 * Update for compatibility with Gutenberg v10.0

--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -25,6 +25,9 @@ This theme is beta software, and is not meant for use on a production site. Bug 
 
 == Changelog ==
 
+= 0.4.5 =
+* Update for compatibility with Gutenberg v10.1
+
 = 0.4.4 =
 * Update for compatibility with Gutenberg v10.0
 

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -7,7 +7,7 @@ Description: TT1 Blocks is an experimental block-based version of the Twenty Twe
 Requires at least: 5.6
 Tested up to: 5.6
 Requires PHP: 5.6
-Version: 0.4.4
+Version: 0.4.5
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: tt1-blocks


### PR DESCRIPTION
Update TT1 Blocks to version 4.4.5. This release includes the switch from the theme's own alignments CSS to the new system baked into Gutenberg v10.3. 

Once this is merged, I'll bundle a new release here in the `theme-experiments` repo, and also upload the new version to the theme repository, to correspond with today's [Gutenberg 10.3 release](https://github.com/WordPress/gutenberg/commits/release/10.3). 