### PR TITLE
Update broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Tip: WordPress will search for themes inside of subdirectories. If you'd like to
 
 Here are some resources that may be useful context for learning more about block-based themes:
 
-- [Block-based Theme Documentation](https://developer.wordpress.org/block-editor/developers/themes/block-based-themes/)
-- [theme.json Documentation](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/themes/theme-json.md)
-- [Creating a block-based theme (tutorial)](https://developer.wordpress.org/block-editor/tutorials/block-based-themes/)
+- [Block-based Theme Documentation](https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/themes/block-based-themes.md)
+- [theme.json Documentation](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/)
+- [Creating a block-based theme (tutorial)](https://developer.wordpress.org/block-editor/how-to-guides/block-theme/)
 - [Full site editing development in the Gutenberg repo](https://github.com/WordPress/gutenberg/labels/%5BFeature%5D%20Full%20Site%20Editing)
 - [Global styles development in the Gutenberg repo](https://github.com/WordPress/gutenberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22Global+Styles%22)
 


### PR DESCRIPTION
Fixes #248. 

The [Block-based Theme Documentation](https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/themes/block-based-themes.md) link needs to continue linking to GitHub, because it's still broken in the handbook as per https://github.com/WordPress/gutenberg/issues/25707. 
