### PR TITLE
Empty theme: use new theme.json shape

### DIFF
--- a/emptytheme/experimental-theme.json
+++ b/emptytheme/experimental-theme.json
@@ -1,29 +1,22 @@
 {
+	"version": 1,
 	"settings": {
-		"defaults": {
-			"color": {
-				"gradients": [ ],
-				"link": true,
-				"palette": [ ]
-			},
-			"spacing": {
-				"customPadding": true
-			},
-			"typography": {
-				"customLineHeight": true,
-				"fontFamilies": [ ],
-				"fontSizes": [ ]
-			},
-			"layout": {
-				"contentSize": "840px",
-				"wideSize": "1100px"
-			}
-		}
-	},
-	"styles": {
-		"root": {
-			"color": { },
-			"typography": { }
+		"color": {
+			"gradients": [],
+			"link": true,
+			"palette": []
+		},
+		"spacing": {
+			"customPadding": true
+		},
+		"typography": {
+			"customLineHeight": true,
+			"fontFamilies": [],
+			"fontSizes": []
+		},
+		"layout": {
+			"contentSize": "840px",
+			"wideSize": "1100px"
 		}
 	}
 }


### PR DESCRIPTION
Accompanying PR for https://github.com/WordPress/gutenberg/pull/30541

See related PR for TT1-blocks at https://github.com/WordPress/theme-experiments/pull/252
