### PR TITLE
Added theme.json styles for button block to (better) align with TwentyTwentyOne button styles

### DIFF
--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -266,7 +266,7 @@
 					"text": "var(--wp--preset--color--green)"
 				},
 				"typography": {
-					"fontSize": "22.5px",
+					"fontSize": "var(--wp--preset--font-size--normal)",
 					"fontWeight": 500
 				}
 			},

--- a/tt1-blocks/experimental-theme.json
+++ b/tt1-blocks/experimental-theme.json
@@ -257,6 +257,19 @@
 					"lineHeight": 1.4
 				}
 			},
+			"core/button": {
+				"border": {
+					"radius": "0px"
+				},
+				"color": {
+					"background": "var(--wp--preset--color--gray)",
+					"text": "var(--wp--preset--color--green)"
+				},
+				"typography": {
+					"fontSize": "22.5px",
+					"fontWeight": 500
+				}
+			},
 			"core/post-author": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--extra-small)",


### PR DESCRIPTION
Target:
![image](https://user-images.githubusercontent.com/146530/116582490-6f1ac500-a8e3-11eb-8250-55c55e45a334.png)

Before:
![image](https://user-images.githubusercontent.com/146530/116582539-7b9f1d80-a8e3-11eb-8125-def2d7944078.png)

After:
![image](https://user-images.githubusercontent.com/146530/116582454-62966c80-a8e3-11eb-8de4-14eea85fe6e3.png)

Editor:
![image](https://user-images.githubusercontent.com/146530/116582647-92de0b00-a8e3-11eb-8ae4-e352996c4d0b.png)

To test add a button to a page. 
Add another button to a page and set the block style to "outline".
Observe that the styles are (closer to) TwentyTwentyOne button styles.