### PR TITLE
Adding bug demonstration

### DIFF
--- a/style-bugger/block-template-parts/header.html
+++ b/style-bugger/block-template-parts/header.html
@@ -1,0 +1,3 @@
+<!-- wp:site-title /-->
+
+<!-- wp:site-tagline /-->

--- a/style-bugger/block-templates/index.html
+++ b/style-bugger/block-templates/index.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query-loop -->
+<!-- wp:post-title {"isLink":true} /-->
+
+<!-- wp:post-excerpt /-->
+<!-- /wp:query-loop -->
+<!-- /wp:query -->

--- a/style-bugger/block-templates/singular.html
+++ b/style-bugger/block-templates/singular.html
@@ -1,0 +1,5 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:post-title /-->
+
+<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/style-bugger/experimental-theme.json
+++ b/style-bugger/experimental-theme.json
@@ -1,0 +1,34 @@
+{
+	"version": 1,
+	"settings": {
+		"color": {
+			"gradients": [],
+			"link": true,
+			"palette": []
+		},
+		"spacing": {
+			"customPadding": true
+		},
+		"typography": {
+			"customLineHeight": true,
+			"fontFamilies": [],
+			"fontSizes": []
+		},
+		"layout": {
+			"contentSize": "840px",
+			"wideSize": "1100px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/quote": {
+				"spacing": {
+					"padding": {
+						"left": "50px",
+						"right": "50px"
+					}
+				}
+			}
+		}
+	}
+}

--- a/style-bugger/functions.php
+++ b/style-bugger/functions.php
@@ -1,0 +1,35 @@
+<?php
+
+if ( ! function_exists( 'style_bugger_support' ) ) :
+	function style_bugger_support()  {
+
+		// Adding support for featured images.
+		add_theme_support( 'post-thumbnails' );
+
+		// Adding support for core block visual styles.
+		add_theme_support( 'wp-block-styles' );
+
+		// Adding support for responsive embedded content.
+		add_theme_support( 'responsive-embeds' );
+
+		// Add support for editor styles.
+		add_theme_support( 'editor-styles' );
+
+		// Enqueue editor styles.
+		add_editor_style( 'style.css' );
+
+		// Add support for custom units.
+		add_theme_support( 'custom-units' );
+	}
+	add_action( 'after_setup_theme', 'style_bugger_support' );
+endif;
+
+/**
+ * Enqueue scripts and styles.
+ */
+function style_bugger_scripts() {
+	// Enqueue theme stylesheet.
+	wp_enqueue_style( 'style-bugger-style', get_template_directory_uri() . '/style.css', array(), wp_get_theme()->get( 'Version' ) );
+}
+
+add_action( 'wp_enqueue_scripts', 'style_bugger_scripts' );

--- a/style-bugger/style.css
+++ b/style-bugger/style.css
@@ -1,0 +1,16 @@
+/*
+Theme Name: style-bugger
+Theme URI: 
+Author: 
+Description: a theme to demo a bug
+Requires at least: 5.3
+Tested up to: 5.5
+Requires PHP: 5.6
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: style-bugger
+
+style-bugger WordPress Theme, (C) 2021 WordPress.org
+style-bugger is distributed under the terms of the GNU GPL.
+*/


### PR DESCRIPTION
This theme demonstrates a bug in Gutenberg where strange things happen.

It seems to have something to do with a block expressing support for a style (or not).  

Or maybe it's coincidental.  

The format (v1 vs v0) doesn't seem to have any bearing.

See [this gutenberg issue](https://github.com/WordPress/gutenberg/issues/31560) for more context.