### PR TITLE
[tt1-blocks]: Update Query block renaming

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -2,8 +2,9 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-	<!-- wp:query-loop -->
+	<!-- wp:query-loop {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
+	<div class="wp-block-query-loop">
+	<!-- wp:post-template -->
 
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
@@ -42,7 +43,7 @@
 		<!-- /wp:spacer -->
 	</div>
 	<!-- /wp:group -->
-	<!-- /wp:query-loop -->
+	<!-- /wp:post-template -->
 
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
@@ -55,7 +56,7 @@
 		<!-- /wp:query-pagination -->
 	</div>
 	<!-- /wp:group -->
-	<!-- /wp:query -->
+	<!-- /wp:query-loop -->
 </main>
 <!-- /wp:group -->
 


### PR DESCRIPTION
A renaming of `Query` and `Query Loop` block is considered in GB and will update the `core` 5.8 here: https://github.com/WordPress/gutenberg/pull/32283

The above PR will rename `Query` and `QueryLoop` blocks to `QueryLoop` and `PostTemplate` respectively.


Since this change will make the previous `Query` blocks to be invalid, block themes must be updated. This PR updates the `tt1-blocks` theme. Similar PRs will be needed for other block themes as well.

## Caution
**Do NOT merge this if the above GB PR has not been merged unless there will is coordination for it with GB team!**