### PR TITLE
TT1 Blocks: Make separators 100% wide by default

### DIFF
--- a/tt1-blocks/assets/css/blocks.css
+++ b/tt1-blocks/assets/css/blocks.css
@@ -187,6 +187,11 @@ hr.is-style-twentytwentyone-separator-thick,
 	display: none;
 }
 
+/* In Twenty Twenty-One, separators should be 100% wide. */
+.wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
+	width: 100%;
+}
+
 /*--------------------------------------------------------------
 # Site Tagline
 --------------------------------------------------------------*/

--- a/tt1-blocks/assets/css/blocks.css
+++ b/tt1-blocks/assets/css/blocks.css
@@ -187,7 +187,7 @@ hr.is-style-twentytwentyone-separator-thick,
 	display: none;
 }
 
-/* In Twenty Twenty-One, separators should be 100% wide. */
+/* In Twenty Twenty-One, separators are 100% wide. This replicates that approach */
 .wp-block-separator:not(.is-style-wide):not(.is-style-dots) {
 	width: 100%;
 }


### PR DESCRIPTION
The thick separators in TT1 Blocks' templates have been broken for a few releases now. They're supposed to stretch full-width, but instead they appear narrow. This doesn't match up with Twenty Twenty-One. 

There's no specific issue for this, though https://github.com/WordPress/theme-experiments/issues/255 seems similar. This PR fixes this via CSS — this behavior is a custom theme decision, so it feels right to do it in CSS. 

Current|Intended
---|---
<img width="1363" alt="Screen Shot 2021-06-01 at 8 57 54 AM" src="https://user-images.githubusercontent.com/1202812/120327497-d39cbb80-c2b7-11eb-907e-f995501ce6b9.png">|<img width="1398" alt="Screen Shot 2021-06-01 at 8 56 38 AM" src="https://user-images.githubusercontent.com/1202812/120327553-e0b9aa80-c2b7-11eb-9eeb-539525ec38f1.png">