### PR TITLE
Update require-gutenberg script & add license

### DIFF
--- a/require-gutenberg/LICENSE
+++ b/require-gutenberg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Ari Stathopoulos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/require-gutenberg/README.md
+++ b/require-gutenberg/README.md
@@ -18,3 +18,7 @@ Everything runs on AJAX so there are no page refreshes.
 
 Simply grab the contents of the `require-gutenberg.php` file and paste them in your `functions.php` file. Alternatively you can include it as a separate file.  
 Once you copy the code to your theme, replace `textdomain` inside the file with your theme's text-domain.
+
+## License
+
+This script is released by [Ari Stathopoulos](https://aristath.github.io) and the [WordPress Themes Team](https://make.wordpress.org/themes/) under the MIT license.

--- a/require-gutenberg/require-gutenberg.php
+++ b/require-gutenberg/require-gutenberg.php
@@ -41,9 +41,6 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 
 			// Handle activating Gutenberg via AJAX.
 			add_action( 'wp_ajax_wpthemes_require_gutenberg_activate_plugin', [ $this, 'activate_plugin' ] );
-
-			// Handle activating a non-FSE theme.
-			add_action( 'switch_theme', [ $this, 'switch_theme' ], 10, 3 );
 		}
 
 		/**
@@ -59,7 +56,7 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 			$active_step = false;
 			if ( ! $this->is_plugin_installed() ) {
 				$active_step = 'install';
-			} elseif ( ! $this->is_plugin_active() || ! $this->is_experiment_enabled() ) {
+			} elseif ( ! $this->is_plugin_active() ) {
 				$active_step = 'activate';
 			}
 
@@ -68,15 +65,15 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 				return;
 			}
 			?>
-			<div class="notice notice-warning require-gutenberg-notice-wrapper notice-alt<?php echo ( $active_step ) ? ' active-step-' . esc_attr( $active_step ) : ''; ?>">
-				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed with the "Full Site Editing" experiment enabled.', 'textdomain' ); ?></p>
+			<div class="notice notice-warning require-gutenberg-notice-wrapper notice-alt active-step-<?php echo esc_attr( $active_step ); ?>">
+				<p><?php esc_html_e( 'This is an experimental theme and requires the Gutenberg plugin to be installed.', 'textdomain' ); ?></p>
 				<div class="require-gutenberg require-gutenberg-install">
 					<p><?php esc_html_e( 'The Gutenberg plugin is not installed. Click the button below to install it.', 'textdomain' ); ?></p>
 					<p><button class="button" onclick="wpThemesRequireGutenberg.installPlugin();" aria-label="<?php esc_attr_e( 'Install Gutenberg', 'textdomain' ); ?>"><?php esc_html_e( 'Install Gutenberg', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-activate">
-					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated, or the "Full Site Editing" experiment is not enabled. Click the button below to enable the plugin and experiment.', 'textdomain' ); ?></p>
-					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin & Experiment.', 'textdomain' ); ?></button></p>
+					<p><?php esc_html_e( 'The Gutenberg plugin is installed but not activated. Click the button below to enable the plugin.', 'textdomain' ); ?></p>
+					<p><button class="button" onclick="wpThemesRequireGutenberg.activatePlugin();"><?php esc_html_e( 'Activate Plugin.', 'textdomain' ); ?></button></p>
 				</div>
 				<div class="require-gutenberg require-gutenberg-success">
 					<p><?php esc_html_e( 'Congratulations! All steps required were completed. Enjoy your Full Site Editing experience.', 'textdomain' ); ?></p>
@@ -214,20 +211,6 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 		}
 
 		/**
-		 * Check if the FSE experiment is enabled.
-		 *
-		 * @access public
-		 *
-		 * @since 1.0.0
-		 *
-		 * @return bool
-		 */
-		public function is_experiment_enabled() {
-			$option = (array) get_option( 'gutenberg-experiments', [] );
-			return ( isset( $option['gutenberg-full-site-editing'] ) && '1' === $option['gutenberg-full-site-editing'] );
-		}
-
-		/**
 		 * Activates the Gutenberg plugin.
 		 *
 		 * @access public
@@ -247,66 +230,13 @@ if ( ! class_exists( 'WPThemes_Require_Gutenberg' ) ) {
 			// Activate plugin.
 			$result = activate_plugin( 'gutenberg/gutenberg.php' );
 
-			// Plugin was successfully activated, now activate the experiment.
+			// Plugin was successfully activated. Exit with success message.
 			if ( ! is_wp_error( $result ) ) {
-
-				// Get option.
-				$option = get_option( 'gutenberg-experiments', [] );
-
-				// Sanity check for option.
-				if ( ! is_array( $option ) ) {
-					$option = [];
-				}
-
-				// Enable experiment.
-				$option['gutenberg-full-site-editing'] = '1';
-
-				// Update the option.
-				update_option( 'gutenberg-experiments', $option );
-
-				// Exit with success message.
 				wp_die( 'success' );
 			}
 
 			// Something went wrong, exit with error message.
 			wp_die( 'error' );
-		}
-
-		/**
-		 * Handle switching themes.
-		 *
-		 * Deactivates the FSE experiment if the theme we're switching to does not support it.
-		 *
-		 * @access public
-		 *
-		 * @param string   $new_name  Name of the new theme.
-		 * @param WP_Theme $new_theme WP_Theme instance of the new theme.
-		 * @param WP_Theme $old_theme WP_Theme instance of the old theme.
-		 *
-		 * @return void
-		 */
-		public function switch_theme( $new_name, $new_theme, $old_theme ) {
-			$new_theme_path = $new_theme->get_template_directory();
-
-			// No need to do anything if the theme we switched to supports Full Site Editing.
-			// Check if the block-templates folder exists, and if it does then early exit.
-			if ( file_exists( $new_theme_path . '/block-templates' ) || is_dir( $new_theme_path . '/block-templates' ) ) {
-				return;
-			}
-
-			// Get option.
-			$option = get_option( 'gutenberg-experiments', [] );
-
-			// Sanity check for option.
-			if ( ! is_array( $option ) ) {
-				$option = [];
-			}
-
-			// Disable experiment.
-			unset( $option['gutenberg-full-site-editing'] );
-
-			// Update the option.
-			update_option( 'gutenberg-experiments', $option );
 		}
 	}
 }


### PR DESCRIPTION
* Adds a license to the script
* Removes code that is no longer necessary since the "experiment" was removed from Gutenberg's options and it is now auto-activated when needed.