### PR TITLE
emptytheme: use post-template instead of query block

### DIFF
--- a/emptytheme/block-templates/index.html
+++ b/emptytheme/block-templates/index.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
 <!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
-<!-- wp:query-loop -->
+<!-- wp:post-template -->
 <!-- wp:post-title {"isLink":true} /-->
 
 <!-- wp:post-excerpt /-->
-<!-- /wp:query-loop -->
+<!-- /wp:post-template -->
 <!-- /wp:query -->


### PR DESCRIPTION
`<!-- wp:query-loop -->` is being deprecated, this PR updates it in emptytheme because I was getting a fatal running Gutenberg trunk related to it.