### PR TITLE
Remove query-loop block usage from tt1 blocks. Update query markup.

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -2,59 +2,61 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true}} -->
-	<!-- wp:query-loop -->
+	<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true},"layout":{"type":"list"}} -->
+	<div class="wp-block-query">
+		<!-- wp:post-template -->
 
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-		<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-title {"isLink":true} /-->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:post-content {"layout":{"inherit":true}} /-->
+
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
+			<!-- wp:spacer {"height":70} -->
+			<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+
+			<!-- wp:separator {"align":"center","className":"is-style-twentytwentyone-separator-thick"} -->
+			<hr class="wp-block-separator aligncenter is-style-twentytwentyone-separator-thick"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:columns -->
+			<div class="wp-block-columns"><!-- wp:column -->
+			<div class="wp-block-column"><!-- wp:post-date /-->
+
+			<!-- wp:post-author {"showAvatar":false} /--></div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column"><!-- wp:post-terms {"term":"category","textAlign":"right"} /-->
+
+			<!-- wp:post-terms {"term":"post_tag","textAlign":"right"} /--></div>
+			<!-- /wp:column --></div>
+			<!-- /wp:columns -->
+
+			<!-- wp:spacer {"height":70} -->
+			<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:group -->
+		<!-- /wp:post-template -->
+
+		<!-- wp:group {"layout":{"inherit":true}} -->
+		<div class="wp-block-group">
+			<!-- wp:query-pagination -->
+			<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+
+			<!-- wp:query-pagination-numbers /-->
+
+			<!-- wp:query-pagination-next /--></div>
+			<!-- /wp:query-pagination -->
+		</div>
+		<!-- /wp:group -->
 	</div>
-	<!-- /wp:group -->
-
-	<!-- wp:post-content {"layout":{"inherit":true}} /-->
-
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-		<!-- wp:spacer {"height":70} -->
-		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-
-		<!-- wp:separator {"align":"center","className":"is-style-twentytwentyone-separator-thick"} -->
-		<hr class="wp-block-separator aligncenter is-style-twentytwentyone-separator-thick"/>
-		<!-- /wp:separator -->
-
-		<!-- wp:columns -->
-		<div class="wp-block-columns"><!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:post-date /-->
-
-		<!-- wp:post-author {"showAvatar":false} /--></div>
-		<!-- /wp:column -->
-
-		<!-- wp:column -->
-		<div class="wp-block-column"><!-- wp:post-terms {"term":"category","textAlign":"right"} /-->
-
-		<!-- wp:post-terms {"term":"post_tag","textAlign":"right"} /--></div>
-		<!-- /wp:column --></div>
-		<!-- /wp:columns -->
-
-		<!-- wp:spacer {"height":70} -->
-		<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-	</div>
-	<!-- /wp:group -->
-	<!-- /wp:query-loop -->
-
-	<!-- wp:group {"layout":{"inherit":true}} -->
-	<div class="wp-block-group">
-		<!-- wp:query-pagination -->
-		<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next /--></div>
-		<!-- /wp:query-pagination -->
-	</div>
-	<!-- /wp:group -->
 	<!-- /wp:query -->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
This replaces query-loop block usage with post-template block usage (query-loop was deprecated, and is throwing warnings on my tests).
It also updates the query block markup (now it has a `<div class="wp-block-query">`container).
I recommend reviewing the PR without whitespace changes, so it is easier to see what was changed https://github.com/WordPress/theme-experiments/pull/276/files?w=1.