### PR TITLE
Emptytheme: experiment with duotone

### DIFF
--- a/emptytheme/theme.json
+++ b/emptytheme/theme.json
@@ -1,22 +1,87 @@
 {
 	"version": 1,
 	"settings": {
+		"border": {
+			"customColor": true,
+			"customRadius": true,
+			"customStyle": true,
+			"customWidth": true
+		},
 		"color": {
+			"customDuotone": true,
+			"duotone": [
+                {
+                    "colors": [ "#000", "#BFF5A5" ],
+                    "slug": "black-and-green",
+                    "name": "Black and Green"
+                }
+            ],
 			"gradients": [],
 			"link": true,
-			"palette": []
+			"palette": [
+				{
+					"slug": "green",
+					"color": "#BFF5A5",
+					"name": "Green"
+				},
+				{
+					"slug": "black",
+					"color": "#000",
+					"name": "Black"
+				}
+			]
 		},
 		"spacing": {
 			"customPadding": true
 		},
 		"typography": {
 			"customLineHeight": true,
-			"fontFamilies": [],
+			"fontFamilies": [
+				{
+					"fontFamily": "sans-serif",
+					"slug": "sans",
+					"name": "Sans"
+				}
+			],
 			"fontSizes": []
 		},
 		"layout": {
-			"contentSize": "840px",
-			"wideSize": "1100px"
+			"contentSize": "560px",
+			"wideSize": "1200px"
+		}
+	},
+	"styles": {
+		"blocks": {
+			"core/image": {
+				"duotone": "black-and-green"
+			},
+			"core/cover": {
+				"spacing": {
+					"padding": "65px"
+				}
+			},
+			"core/button": {
+				"border": {
+					"radius": "0px"
+				},
+				"spacing": {
+					"padding": {
+						"left": "80px",
+						"right": "80px"
+					}
+				},
+				"color": {
+					"background": "var(--wp--preset--color--green)",
+					"text": "var(--wp--preset--color--black)"
+				}
+			}
+		},
+		"typography": {
+			"fontFamily": "var(--wp--preset--body--typography--font-family)"
+		},
+		"color": {
+			"background": "var(--wp--preset--color--green)",
+			"text": "var(--wp--preset--color--black)"
 		}
 	}
 }


### PR DESCRIPTION
This PR is just an experiment to highlight what can be done with theme.json.

Add this content to a page:
```

<!-- wp:cover {"url":"http://experiments.local/wp-content/uploads/2021/07/guy-man_FSXSYPD4ZV.jpg","id":108,"dimRatio":0,"contentPosition":"bottom left","align":"full","style":{"color":{"duotone":["#000","#BFF5A5"]}}} -->
<div class="wp-block-cover alignfull has-custom-content-position is-position-bottom-left"><img class="wp-block-cover__image-background wp-image-108" alt="" src="http://experiments.local/wp-content/uploads/2021/07/guy-man_FSXSYPD4ZV.jpg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","textColor":"green","fontSize":"large"} -->
<p class="has-text-align-center has-green-color has-text-color has-large-font-size">Ready to skate?</p>
<!-- /wp:paragraph -->

<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link">SIGN UP</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div></div>
<!-- /wp:cover -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```