### PR TITLE
Readme: Add instructions for registering additional theme directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ We encourage you to submit your experiment to be included! To get started, check
 
 Most of the themes here rely on experimental Gutenberg functionality that must be turned on manually. We recommend testing with WordPress 5.3 or higher, PHP 7.3 or higher, and the latest version of the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/). Here are general instructions for getting started:
 
-1. Clone this repository or upload a zip of the theme into your site’s themes directory.
-2. Install the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
-3. Enable the "Full Site Editing" experiment in the `Gutenberg > Experiments` panel.
-4. Activate the new theme from within `Appearance > Themes`.
+1. Clone this repository, or upload a zip of the theme, into your site’s `wp-content/themes` directory. If you clone the repository, you'll need to add this to a file in the `wp-content/mu-plugins/` folder:
+    ```
+    register_theme_directory( WP_CONTENT_DIR . '/themes/theme-experiments' );
+    ```
+    
+3. Install the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
+4. Enable the "Full Site Editing" experiment in the `Gutenberg > Experiments` panel.
+5. Activate the new theme from within `Appearance > Themes`.
 
 If the theme includes starter content, you'll want to install on a fresh site, and visit the Customizer after installation. Pressing the "Publish" in there should auto-populate the starter content. 
 


### PR DESCRIPTION
AFAIK, this is required to make the themes available. It won't be obvious to everyone, though, so some folks might be confused when they don't see the themes appear in `wp-admin`.