### PR TITLE
TT1-Blocks: Update Query block in index template to use displayLayout instead of layout

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-	<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true},"layout":{"type":"list"}} -->
+	<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":"100","offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","inherit":true},"displayLayout":{"type":"list"}} -->
 	<div class="wp-block-query">
 		<!-- wp:post-template -->
 


### PR DESCRIPTION
On a fresh install of Gutenberg, running in `wp-env`, I noticed that the current `index.html` template throws an error, due to the `layout` attribute being set to an invalid value (`list`):

<img src="https://user-images.githubusercontent.com/14988353/142974493-3e25ee83-0bb5-499c-aaee-5c6820643a92.png" width="500" />

This then throws an error in `useAvailableAlignments` [at this line](https://github.com/wordpress/gutenberg/blob/32ecd97e988174b6401289c44200135c224ca104/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js#L34)

![image](https://user-images.githubusercontent.com/14988353/142974583-3140050c-a0c6-43c7-91bf-86af093b2f01.png)

This is because the `layout` attribute in this markup should be `displayLayout`, as `layout` is reserved for the Layout block support. The switch to `displayLayout` was introduced in https://github.com/WordPress/gutenberg/pull/31833 (back in May).

It seems that this error occurs because for the current markup the `layout` attribute is being used directly in the Query block [here](https://github.com/wordpress/gutenberg/blob/4d3fb72d301f26bcf13f3117cec7e5abe60f399e/packages/block-library/src/query/edit/index.js#L47) — and because the current markup includes the container `div`, it never gets migrated via a deprecation (which [usually handles the migration](https://github.com/wordpress/gutenberg/blob/bf405a3f1280cade6b9f480c973261b987d5fd53/packages/block-library/src/query/deprecated.js#L49) from `layout` to `displayLayout`).

Just to double-check before we do any further work in Gutenberg, @jorgefilipecosta it looks like this markup was last updated in https://github.com/WordPress/theme-experiments/pull/276 — do you remember if the updated markup was copy + pasted or hand-edited? Just trying to work out whether the markup here had a typo, or if we need additional deprecations in Gutenberg to handle this case?

### Steps to test

With Gutenberg activated, go to create a new page and copy and paste the existing markup for the `wp:query` block [from this file](https://github.com/WordPress/theme-experiments/blob/master/tt1-blocks/block-templates/index.html) into the code editor view. You should see the error message in the screenshot above when you switch back to the visual editor.

Edit the markup in the code editor view and copy paste the change in this PR over the existing markup. When you switch back to the visual editor view, there should no longer be an error. Or, alternately, spin up a new WP instance and use this PR to load the TT1-Blocks theme. When you open the site editor, there should be no errors in the Query block.