### PR TITLE
Emptytheme: Stop clearing presets

### DIFF
--- a/emptytheme/theme.json
+++ b/emptytheme/theme.json
@@ -2,14 +2,6 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
-		"color": {
-			"gradients": [],
-			"palette": []
-		},
-		"typography": {
-			"fontFamilies": [],
-			"fontSizes": []
-		},
 		"layout": {
 			"contentSize": "840px",
 			"wideSize": "1100px"


### PR DESCRIPTION
Emptytheme contains the following code in its theme.json, which is a helpful starting place for theme authors to populate:

```
		"color": {
			"gradients": [],
			"palette": []
		},
		"typography": {
			"fontFamilies": [],
			"fontSizes": []
		},
```

... but the downside is that this clears out those presets, and makes their associated tools unavailable (as noticed by @jasmussen [here](https://github.com/WordPress/gutenberg/pull/37446#issuecomment-995608534)). 

I think it makes sense to remove them. 