### PR TITLE
TT1 Blocks: fixed query pagination markup

### DIFF
--- a/tt1-blocks/block-templates/index.html
+++ b/tt1-blocks/block-templates/index.html
@@ -46,12 +46,12 @@
 
 		<!-- wp:group {"layout":{"inherit":true}} -->
 		<div class="wp-block-group">
-			<!-- wp:query-pagination -->
-			<div class="wp-block-query-pagination"><!-- wp:query-pagination-previous /-->
+			<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
 
 			<!-- wp:query-pagination-numbers /-->
 
-			<!-- wp:query-pagination-next /--></div>
+			<!-- wp:query-pagination-next /-->
 			<!-- /wp:query-pagination -->
 		</div>
 		<!-- /wp:group -->


### PR DESCRIPTION
The query pagination no longer needs a div wrapper, this PR removes it and adds space-between justification to the content.

Before:

<img width="856" alt="Screenshot 2021-12-17 at 17 23 51" src="https://user-images.githubusercontent.com/3593343/146576671-fbe5a5d6-b92a-49b1-a914-29bc0f6bedd7.png">

After:

<img width="721" alt="Screenshot 2021-12-17 at 17 23 40" src="https://user-images.githubusercontent.com/3593343/146576677-21dfbb53-f5d1-4bbb-bb0b-0ddb796d8f3c.png">

