### PR TITLE
Fix T11 Blocks editor block margins and add `appearanceTools` support

### DIFF
--- a/tt1-blocks/theme.json
+++ b/tt1-blocks/theme.json
@@ -13,7 +13,6 @@
 	"settings": {
 		"appearanceTools": true,
 		"color": {
-			"link": true,
 			"palette": [
 				{
 					"slug": "black",
@@ -114,7 +113,6 @@
 			"wideSize": "1240px"
 		},
 		"typography": {
-			"customLineHeight": true,
 			"fontSizes": [
 				{
 					"slug": "extra-small",
@@ -175,22 +173,6 @@
 					"slug": "hoefler-times-new-roman"
 				}
 			]
-		},
-		"spacing": {
-			"customPadding": true,
-			"units": [
-				"px",
-				"em",
-				"rem",
-				"vh",
-				"vw"
-			]
-		},
-		"border": {
-			"customColor": true,
-			"customRadius": true,
-			"customStyle": true,
-			"customWidth": true
 		},
 		"custom": {
 			"font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",

--- a/tt1-blocks/theme.json
+++ b/tt1-blocks/theme.json
@@ -11,6 +11,7 @@
 		}
 	],
 	"settings": {
+		"appearanceTools": true,
 		"color": {
 			"link": true,
 			"palette": [


### PR DESCRIPTION
This setting activates block editor-controlled margins for TT1 Blocks. Resolves zeroed margin issue for vertically adjacent blocks in editor.

Also enables additional style control support, [included in WordPress 5.9](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/).

### BEFORE FIX: Adjacent **Buttons** blocks with no vertical margin:
<img width="1115" alt="tt1-blocks_appearanceTools-disabled-default" src="https://user-images.githubusercontent.com/824344/152473254-5ad82011-ea97-415f-82bd-27971386688a.png">

### AFTER FIX: Default vertical margins applied by block editor for adjacent **Buttons** blocks:
<img width="1114" alt="tt1-blocks_appearanceTools-enabled" src="https://user-images.githubusercontent.com/824344/152473266-41023149-c5a6-45d1-b7f5-38323391c9df.png">

Testing:
- Update tested to resolve display issue (screens above via a4be98961137fbe800d24e2a69d2f846b7a486ff).
- Update tested to confirm `appearanceTools` features remain enabled after removing manual settings (7a41a38d6bad7990ce971c9ba465a14178040a4b).

References:
- https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/

Related:
- https://core.trac.wordpress.org/ticket/54250
- https://github.com/WordPress/twentytwentytwo/issues/261
- https://github.com/WordPress/twentytwentytwo/pull/263
